### PR TITLE
adding tti payload variable "frm_payload"

### DIFF
--- a/decoders/connector/advantech/wise-2410/v1.0.0/payload.ts
+++ b/decoders/connector/advantech/wise-2410/v1.0.0/payload.ts
@@ -1138,7 +1138,9 @@ function checkPayloadLengthAndSetStorage(hexArr, sequence) {
   }
 }
 
-const WISE2410Payloadd = payload.find((x) => x.variable === "payload_raw" || x.variable === "payload" || x.variable === "data" || x.variable === "payload_hex");
+const WISE2410Payloadd = payload.find(
+  (x) => x.variable === "payload_raw" || x.variable === "payload" || x.variable === "frm_payload" || x.variable === "data" || x.variable === "payload_hex"
+);
 
 ////////////////////////////////////////////
 // Main


### PR DESCRIPTION
## Decoder Description

Adding the frm_payload variable to the wise 2410 connector, needed when a user utilizes the TTI Network payload parser as the payload is sent forward as "frm_payload"

## Type of change

- [ ] Adding a new Decoder of Connector
- [ ] Adding a new Decoder of Network
- [X] Update or fixing an issue in existing Decoder

## Decoder Information and Payload to test and review

- [ ] Documentation of the hardware or protocol:
- [ ] Payload of example the test the decoder:


## Checklist for Adding a New Decoder

- [ ] Created a new folder under `./decoders/network/` or `./decoders/connector/` with the name of your decoder.
- [ ] Added a `network.jsonc` or `connector.jsonc` file that follows the structure defined in `./schema/`.
- [ ] Created version folders and added `manifest.jsonc` files for each version.
- [ ] Followed the folder structure guidelines for manufacturer and sensor/device model.
- [ ] The code has unit test and it's in TypeScript.

## Additional Notes

Please add any other information that you think is important.

