### PR TITLE
Remove empty "object" variable from payload.js

### DIFF
--- a/decoders/network/lorawan-chirpstack/v1.0.0/payload.js
+++ b/decoders/network/lorawan-chirpstack/v1.0.0/payload.js
@@ -254,12 +254,12 @@ if (chirpstack_payload) {
     delete chirpstack_payload.tags;
   }
 
-  // make sure that the variable with the name "object" does not have an empty value, this has been added since we do not support more complex decoded object structures
-  const objectIndex = vars_to_tago.findIndex(
-    (item) => item.variable === "object"
-  );
-  if (objectIndex !== -1 && !vars_to_tago[objectIndex].value) {
-    vars_to_tago.splice(objectIndex, 1);
+  // Decoded Codec
+  if (chirpstack_payload.object) {
+    vars_to_tago = vars_to_tago.concat(
+      toTagoFormat(chirpstack_payload.object, serie)
+    );
+    delete chirpstack_payload.object;
   }
 
   vars_to_tago = vars_to_tago.concat(toTagoFormat(chirpstack_payload, serie));

--- a/decoders/network/lorawan-chirpstack/v1.0.0/payload.js
+++ b/decoders/network/lorawan-chirpstack/v1.0.0/payload.js
@@ -253,6 +253,15 @@ if (chirpstack_payload) {
     vars_to_tago = vars_to_tago.concat(toTagoFormat(chirpstack_payload.tags, serie));
     delete chirpstack_payload.tags;
   }
+
+  // make sure that the variable with the name "object" does not have an empty value, this has been added since we do not support more complex decoded object structures
+  const objectIndex = vars_to_tago.findIndex(
+    (item) => item.variable === "object"
+  );
+  if (objectIndex !== -1 && !vars_to_tago[objectIndex].value) {
+    vars_to_tago.splice(objectIndex, 1);
+  }
+
   vars_to_tago = vars_to_tago.concat(toTagoFormat(chirpstack_payload, serie));
 
   // Change the payload to the new formated variables.


### PR DESCRIPTION
## Decoder Description

Adding removal of the empty "object" key. An empty object key is generated by the toTagoFormat function whenever chirpstack sends a multi leveled json of decoded data from their CODEC. 

Added the removal of the object key if its value is empty since this causes connectors to fail.

## Type of change

- [ ] Adding a new Decoder of Connector
- [ ] Adding a new Decoder of Network
- [X] Update or fixing an issue in existing Decoder

## Decoder Information and Payload to test and review

- [ ] Documentation of the hardware or protocol:
- [ ] Payload of example the test the decoder:


## Checklist for Adding a New Decoder

- [ ] Created a new folder under `./decoders/network/` or `./decoders/connector/` with the name of your decoder.
- [ ] Added a `network.jsonc` or `connector.jsonc` file that follows the structure defined in `./schema/`.
- [ ] Created version folders and added `manifest.jsonc` files for each version.
- [ ] Followed the folder structure guidelines for manufacturer and sensor/device model.
- [ ] The code has unit test and it's in TypeScript.

## Additional Notes

Please add any other information that you think is important.

