### PR TITLE
Group must be string, not number

### DIFF
--- a/decoders/connector/dragino/cs01lb/v1.0.0/payload.ts
+++ b/decoders/connector/dragino/cs01lb/v1.0.0/payload.ts
@@ -179,7 +179,7 @@ if (cs01lb_payload) {
   try {
     // Convert the data from Hex to Javascript Buffer.
     const buffer = Buffer.from(cs01lb_payload.value, "hex");
-    const group = new Date().getTime();
+    const group = new Date().getTime().toString();
     const payload_aux = Decoder(buffer, Number(port.value));
     payload = payload.concat(toTagoFormat(payload_aux, group));
   } catch (e) {


### PR DESCRIPTION
## Decoder Description

Making group be a string instead of number, this was causing parsing issues. 

## Type of change

- [ ] Adding a new Decoder of Connector
- [ ] Adding a new Decoder of Network
- [X] Update or fixing an issue in existing Decoder

## Decoder Information and Payload to test and review

- [ ] Documentation of the hardware or protocol:
- [ ] Payload of example the test the decoder:


## Checklist for Adding a New Decoder

- [ ] Created a new folder under `./decoders/network/` or `./decoders/connector/` with the name of your decoder.
- [ ] Added a `network.jsonc` or `connector.jsonc` file that follows the structure defined in `./schema/`.
- [ ] Created version folders and added `manifest.jsonc` files for each version.
- [ ] Followed the folder structure guidelines for manufacturer and sensor/device model.
- [ ] The code has unit test and it's in TypeScript.

## Additional Notes

Please add any other information that you think is important.

