### PR TITLE
fix group from number to string, fixed not picking up port variable from chirpstack network.

### DIFF
--- a/decoders/connector/dragino/cpl03lb/v1.0.0/payload.ts
+++ b/decoders/connector/dragino/cpl03lb/v1.0.0/payload.ts
@@ -216,14 +216,17 @@ const cplo03lb_payload = payload.find(
 );
 
 const port = payload.find(
-  (x) => x.variable === "port" || x.variable === "fport"
+  (x) => 
+    x.variable === "port" || 
+    x.variable === "fport" || 
+    x.variable === "fPort"
 );
 
 if (cplo03lb_payload) {
   try {
     // Convert the data from Hex to Javascript Buffer.
     const buffer = Buffer.from(cplo03lb_payload.value, "hex");
-    const group = new Date().getTime();
+    const group = new Date().toISOString();
     const payload_aux = Decoder(buffer, Number(port.value));
     payload = payload.concat(toTagoFormat(payload_aux, group));
   } catch (e) {


### PR DESCRIPTION
## Decoder Description

Related to a ticket where the user couldn't utilize the Chirpstack network along with this connector since the Chirpstack network generates the "fPort" variable instead of "fport". Also changed group from number to dtring type.

## Type of change

- [ ] Adding a new Decoder of Connector
- [ ] Adding a new Decoder of Network
- [X] Update or fixing an issue in existing Decoder

## Decoder Information and Payload to test and review

- [ ] Documentation of the hardware or protocol:
- [X] Payload of example the test the decoder:


## Checklist for Adding a New Decoder

- [X] Created a new folder under `./decoders/network/` or `./decoders/connector/` with the name of your decoder.
- [X] Added a `network.jsonc` or `connector.jsonc` file that follows the structure defined in `./schema/`.
- [X] Created version folders and added `manifest.jsonc` files for each version.
- [X] Followed the folder structure guidelines for manufacturer and sensor/device model.
- [X] The code has unit test and it's in TypeScript.

## Additional Notes

Please add any other information that you think is important.

