### PR TITLE
Fix firmware iteration conversion in payload.js and add payload.test.ts

### DIFF
--- a/decoders/connector/abeeway/compact-tracker/v1.0.0/payload.js
+++ b/decoders/connector/abeeway/compact-tracker/v1.0.0/payload.js
@@ -56,12 +56,12 @@ function Decoder(bytes) {
     }
     const mcu_firmware_major_version = bytes[6];
     const mcu_firmware_minor_version = bytes[7];
-    let mcu_firmware_iteration = bytes[8];
+    let mcu_firmware_iteration = bytes[8].toString();
     mcu_firmware_iteration = mcu_firmware_iteration.concat(mcu_firmware_major_version, mcu_firmware_minor_version);
 
     const ble_firmware_major_version = bytes[9];
     const ble_firmware_minor_version = bytes[10];
-    let ble_firmware_iteration = bytes[11];
+    let ble_firmware_iteration = bytes[11].toString();;
     ble_firmware_iteration = ble_firmware_iteration.concat(ble_firmware_major_version, ble_firmware_minor_version);
 
     return [

--- a/decoders/connector/abeeway/compact-tracker/v1.0.0/payload.test.ts
+++ b/decoders/connector/abeeway/compact-tracker/v1.0.0/payload.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import * as ts from "typescript";
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { DataToSend } from "@tago-io/sdk/lib/types";
+
+const file = readFileSync(join(__dirname, "./payload.js"));
+const transpiledCode = ts.transpile(file.toString());
+
+let payload: DataToSend[] = [];
+let device: { params: { key: string; value: string }[] };
+
+describe("Device Payload Validation", () => {
+  beforeEach(() => {
+    payload = [{ variable: "payload", value: "056062880040020600030305" }];
+    device = { params: [{ key: "beacon_decoder", value: "simple" }] };
+  });
+
+  test("Check all output variables for acceleration", () => {
+    const result = eval(transpiledCode);
+
+    expect(result).toEqual(expect.arrayContaining([expect.objectContaining({ variable: "payload", value: "056062880040020600030305" })]));
+    expect(result).toEqual(expect.arrayContaining([expect.objectContaining({ variable: "type", value: 5 })]));
+    expect(result).toEqual(expect.arrayContaining([expect.objectContaining({ variable: "cause", value: "System Request (application) Reset" })]));
+    expect(result).toEqual(expect.arrayContaining([expect.objectContaining({ variable: "mcu_firmware_iteration", value: "026" })]));
+    expect(result).toEqual(expect.arrayContaining([expect.objectContaining({ variable: "ble_firmware_iteration", value: "533" })]));
+  });
+});


### PR DESCRIPTION
## Decoder Description

Adding toString() to a part in the code which was causing issues since conact can't be used on a number type.

## Type of change

- [ ] Adding a new Decoder of Connector
- [ ] Adding a new Decoder of Network
- [x] Update or fixing an issue in existing Decoder

## Decoder Information and Payload to test and review

- [ ] Documentation of the hardware or protocol:
- [x] Payload of example the test the decoder:


## Checklist for Adding a New Decoder

- [x] Created a new folder under `./decoders/network/` or `./decoders/connector/` with the name of your decoder.
- [x] Added a `network.jsonc` or `connector.jsonc` file that follows the structure defined in `./schema/`.
- [x] Created version folders and added `manifest.jsonc` files for each version.
- [x] Followed the folder structure guidelines for manufacturer and sensor/device model.
- [x] The code has unit test and it's in TypeScript.

## Additional Notes

Please add any other information that you think is important.

