### PR TITLE
Fixes for Volley Boast connectors decoder to decoders main

### DIFF
--- a/decoders/connector/volley-boast/vobo-gp-1/v1.0.0/payload.js
+++ b/decoders/connector/volley-boast/vobo-gp-1/v1.0.0/payload.js
@@ -8,11 +8,18 @@ function customDecoder(bytes, fport) {
     //=======================================================
     // Insert your customization here
     if (fport == 30) {
-        var tagoDecoded = {
+        var tagoDecoded = [
+            {
             variable: decoded.data.analogSensorString0,
             value: decoded.data.sensorData0,
             units: decoded.data.engUnitsString0
-        }
+            }
+        ];
+        tagoDecoded.push(
+            { variable: "fport", value: decoded.data.fport },
+            { variable: "voboType", value: decoded.data.voboType },
+            { variable: "payloadType", value: decoded.data.payloadType }
+        );
     }
     else if (fport == 40) {
         var tagoDecoded = [
@@ -26,14 +33,18 @@ function customDecoder(bytes, fport) {
                 value: decoded.data.sensorData1,
                 units: decoded.data.engUnitsString1
             }
-        ]
+        ];
+        tagoDecoded.push(
+            { variable: "fport", value: decoded.data.fport },
+            { variable: "voboType", value: decoded.data.voboType },
+            { variable: "payloadType", value: decoded.data.payloadType }
+        );
     }
     else if (fport == 50) {
         var tagoDecoded = decoded.data.digitalSensorStrings.map((sensor, index) => ({
             variable: sensor,
             value: decoded.data.digitalSensorData[index]
         }));
-
         tagoDecoded.push(
             { variable: "fport", value: decoded.data.fport },
             { variable: "voboType", value: decoded.data.voboType },
@@ -46,12 +57,22 @@ function customDecoder(bytes, fport) {
             value: payloadObj.sensorData0,
             units: decoded.data[`engUnitsString${index}`]
         }));
+        tagoDecoded.push(
+            { variable: "fport", value: decoded.data.fport },
+            { variable: "voboType", value: decoded.data.voboType },
+            { variable: "payloadType", value: decoded.data.payloadType }
+        );
     }
     else if (fport == 120) {
         var tagoDecoded = Object.entries(decoded.data.modbusSlots).map(([key, value]) => ({
             variable: key,
             value: value
         }));
+        tagoDecoded.push(
+            { variable: "fport", value: decoded.data.fport },
+            { variable: "voboType", value: decoded.data.voboType },
+            { variable: "payloadType", value: decoded.data.payloadType }
+        );
     }
     else {
         var tagoDecoded = Object.entries(decoded.data).map(([key, value]) => ({
@@ -63,13 +84,13 @@ function customDecoder(bytes, fport) {
     return tagoDecoded;
 }
 
-const DECODER_MAJOR_VERSION=2,DECODER_MINOR_VERSION=1,DECODER_PATCH_VERSION=1;function decodeUplink(a){return Decoder(a.bytes,a.fPort)}
-function Decoder(a,b){var c={},d=[];1==b?c=parseStandardPayload(a):2<=b&&9>=b?c=parseModbusStandardPayload(a,b):10==b?c=parseHeartbeat1p0Payload(a):20<=b&&29>=b?c=parseHeartbeat2p0Payload(a):30<=b&&39>=b?c=parseOneAnalogSensorPayload(a):40<=b&&49>=b?c=parseTwoAnalogSensorsPayload(a):50<=b&&59>=b?c=parseDigitalSensorsPayload(a):60<=b&&69>=b?c=parseEventLogPayload(a):70<=b&&79>=b?c=parseConfigurationPayload(a,b):100<=b&&109>=b?c=parseModbusGenericPayload(a,b):110<=b&&119>=b?c=parseAnalogInputVariableLengthPayload(a,
-b):120<=b&&129>=b?c=parseModbusStandardVariableLengthPayload(a,b):d.push("unknown FPort");a=addVoboMetadata(c,b);a.warnings=[];a.errors=d;return a}
+const DECODER_MAJOR_VERSION=2,DECODER_MINOR_VERSION=2,DECODER_PATCH_VERSION=0;function decodeUplink(a){return Decoder(a.bytes,a.fPort)}
+function Decoder(a,b){var c={},d=[];1==b?c=parseStandardPayload(a):2<=b&&9>=b?c=parseModbusStandardPayload(a,b):10==b?c=parseHeartbeat1p0Payload(a):20<=b&&29>=b?c=parseHeartbeat2p0Payload(a):30<=b&&39>=b?c=parseOneAnalogSensorPayload(a):40<=b&&49>=b?c=parseTwoAnalogSensorsPayload(a):50<=b&&59>=b?c=parseDigitalSensorsPayload(a):60<=b&&69>=b?c=parseEventLogPayload(a):70<=b&&79>=b?c=parseConfigurationPayload(a,b):80<=b&&89>=b?c=parseEventLogPayload(a):100<=b&&109>=b?c=parseModbusGenericPayload(a,b):
+110<=b&&119>=b?c=parseAnalogInputVariableLengthPayload(a,b):120<=b&&129>=b?c=parseModbusStandardVariableLengthPayload(a,b):d.push("unknown FPort");a=addVoboMetadata(c,b);a.warnings=[];a.errors=d;return a}
 function addVoboMetadata(a,b){var c={};c.data=a;var d=a="",e=b%10;0==e||1<=b&&10>b?a="VoBoXX":1==e?a="VoBoTC":2==e&&(a="VoBoXP");if(1==b)d="Standard";else if(2<=b&&9>=b)d="Modbus Standard";else if(10==b)d="Heartbeat 1.0";else if(20<=b&&29>=b)d="Heartbeat 2.0";else if(30<=b&&39>=b)d="One Analog Input",c.data.analogSensorString0=lookupAnalogSensorName(a,c.data.sensorNum0),c.data.engUnitsString0=lookupUnits(1,c.data.sensorUnits0);else if(40<=b&&49>=b)d="Two Analog Inputs",c.data.analogSensorString0=
 lookupAnalogSensorName(a,c.data.sensorNum0),c.data.engUnitsString0=lookupUnits(1,c.data.sensorUnits0),c.data.analogSensorString1=lookupAnalogSensorName(a,c.data.sensorNum1),c.data.engUnitsString1=lookupUnits(1,c.data.sensorUnits1);else if(50<=b&&59>=b)for(d="Digital Inputs",c.data.digitalSensorStrings=[],c.data.digitalSensorData=[],e=0;16>e;e++)1==(c.data.sensorValid0>>e&1)&&(c.data.digitalSensorStrings.push(lookupDigitalSensorName(a,e)),c.data.digitalSensorData.push(c.data.sensorData0>>e&1));else if(60<=
-b&&69>=b)d="Event Log";else if(70<=b&&79>=b)d="Configuration";else if(100<=b&&109>=b)d="Modbus Generic";else if(110<=b&&119>=b)for(d="Analog Input Variable Length",e=0;e<c.data.numOfAinPayloads;e++)c.data["analogSensorString"+e]=lookupAnalogSensorName(a,c.data.ainPayloads[e].sensorNum0),c.data["engUnitsString"+e]=lookupUnits(1,c.data.ainPayloads[e].sensorUnits0);else 120<=b&&129>=b&&(d="Modbus Standard Variable Length");c.data.fport=b;c.data.voboType=a;c.data.payloadType=d;return c}
-function parseStandardPayload(a){var b={};b.DIN1=a[0]&1;b.DIN2=a[0]>>1&1;b.DIN3=a[0]>>2&1;b.WKUP=a[0]>>3&1;b.ADC1=(a[0]&240)>>4|a[1]<<4;b.ADC2=(a[3]&15)<<8|a[2];b.ADC3=(a[3]&240)>>4|a[4]<<4;b.Battery=4*((a[6]&15)<<8|a[5]);b.Temperature=0==(a[7]>>7&1)?.125*((a[6]&240)>>4|a[7]<<4):-.125*(4096-((a[6]&240)>>4|a[7]<<4));b.Modbus0=a[9]<<8|a[8];return b}
+b&&69>=b)d="Event Log";else if(70<=b&&79>=b)d="Configuration";else if(80<=b&&89>=b)d="Notification";else if(100<=b&&109>=b)d="Modbus Generic";else if(110<=b&&119>=b)for(d="Analog Input Variable Length",e=0;e<c.data.numOfAinPayloads;e++)c.data["analogSensorString"+e]=lookupAnalogSensorName(a,c.data.ainPayloads[e].sensorNum0),c.data["engUnitsString"+e]=lookupUnits(1,c.data.ainPayloads[e].sensorUnits0);else 120<=b&&129>=b&&(d="Modbus Standard Variable Length");c.data.fport=b;c.data.voboType=a;c.data.payloadType=
+d;return c}function parseStandardPayload(a){var b={};b.DIN1=a[0]&1;b.DIN2=a[0]>>1&1;b.DIN3=a[0]>>2&1;b.WKUP=a[0]>>3&1;b.ADC1=(a[0]&240)>>4|a[1]<<4;b.ADC2=(a[3]&15)<<8|a[2];b.ADC3=(a[3]&240)>>4|a[4]<<4;b.Battery=4*((a[6]&15)<<8|a[5]);b.Temperature=0==(a[7]>>7&1)?.125*((a[6]&240)>>4|a[7]<<4):-.125*(4096-((a[6]&240)>>4|a[7]<<4));b.Modbus0=a[9]<<8|a[8];return b}
 function parseModbusStandardPayload(a,b){b=5*(b-1)-4;var c={};c["Modbus"+b++]=a[1]<<8|a[0];c["Modbus"+b++]=a[3]<<8|a[2];c["Modbus"+b++]=a[5]<<8|a[4];c["Modbus"+b++]=a[7]<<8|a[6];c["Modbus"+b]=a[9]<<8|a[8];return c}
 function parseHeartbeat1p0Payload(a){var b={};b.batteryLevelMV=4*((a[1]&15)<<8|a[0]);b.fwVersionMajor=a[2]&15|(a[1]&240)>>4;b.fwVersionMinor=a[3]&15|(a[2]&240)>>4;b.fwVersionPatch=a[4]&15|(a[3]&240)>>4;b.fwVersionCustom=(a[4]&240)>>4;b.recSignalLevels=-1*a[5];b.analogVoltageConfig=a[6]&31;b.analogPowerTimeConfig=parseFloat((((a[7]&31)<<3|(a[6]&224)>>5)/10).toFixed(1));b.failedTransmissionBeforeRejoinConfig=(a[8]&1)<<3|(a[7]&224)>>5;b.cycleThroughFSB=(a[8]&2)>>1;b.ackEnable=(a[8]&4)>>2;b.ackFreq=(a[8]&
 120)>>3;b.ackReq=(a[9]&7)<<1|(a[8]&128)>>7;b.batteryLevelThreshold=4*((a[10]&127)<<5|(a[9]&248)>>3);return b}
@@ -77,8 +98,8 @@ function parseHeartbeat2p0Payload(a){var b={};b.batteryLevel=(a[1]&15)<<8|a[0];b
 function bytesToFloat32(a){var b=new ArrayBuffer(4),c=new Uint8Array(b);c[0]=a[0];c[1]=a[1];c[2]=a[2];c[3]=a[3];return(new DataView(b)).getFloat32(0,!1)}function parseOneAnalogSensorPayload(a){var b={};b.sensorNum0=a[0];b.sensorUnits0=a[1];b.sensorData0=bytesToFloat32(a.slice(2,6));return b}
 function parseTwoAnalogSensorsPayload(a){var b={};b.sensorNum0=(a[0]&240)>>4;b.sensorUnits0=a[1];b.sensorData0=bytesToFloat32(a.slice(2,6));b.sensorNum1=a[0]&15;b.sensorUnits1=a[6];b.sensorData1=bytesToFloat32(a.slice(7,11));return b}function parseDigitalSensorsPayload(a){var b={};b.sensorValid0=a[1]<<8|a[0];b.sensorData0=a[3]<<8|a[2];return b}
 function parseEventLogPayload(a){var b={};b.eventTimestamp=a[0]+a[1]*Math.pow(2,8)+a[2]*Math.pow(2,16)+a[3]*Math.pow(2,24);b.eventCode=a[4]+a[5]*Math.pow(2,8);b.metadata=Array.prototype.slice.call(a.slice(6,11),0);return b}
-function parseVoboLibGeneralConfigurationPayload(a){var b={};b.subgroupID=a[0]&15;b.sequenceNumber=(a[0]&240)>>4;0==b.sequenceNumber&&(b.transRejoin=a[1]&15,b.ackFrequency=(a[1]&240)>>4,b.lowBattery=parseFloat(((a[2]&15)/10+2.5).toFixed(1)),b.reserved1=(a[2]&16)>>4,b.heartbeatAckEnable=!!((a[2]&32)>>5),b.operationMode=(a[2]&64)>>6,b.cycleSubBands=!!((a[2]&128)>>7),b.ackRetries=a[3]&7,b.reservedLL=(a[3]&56)>>3,b.ackEnable=!!((a[3]&64)>>6),b.heartbeatEnable=!!((a[3]&128)>>7),b.cycleTime=(a[6]&3)<<16|
-a[5]<<8|a[4],b.backOffReset=(a[6]&252)>>2,b.reservedRD=a[7]&63,b.reserved2=(a[7]&192)>>6,b.resendAttempts=a[8]&15,b.freqSubBand=(a[8]&240)>>4);if(1==b.sequenceNumber){b.timeSyncInterval=a[1];b.joinEUI="";for(let c=9;2<=c;c--)b.joinEUI+=a[c].toString(16).toUpperCase().padStart(2,0),2!=c&&(b.joinEUI+="-");b.joinNonceResetEnable=!!(a[10]&1);b.timeSyncWakeupEnable=!!((a[10]&2)>>1);b.reserved1=(a[10]&252)>>2}return b}
+function parseVoboLibGeneralConfigurationPayload(a,b){var c={};c.subgroupID=a[0]&15;c.sequenceNumber=(a[0]&240)>>4;0==c.sequenceNumber&&(c.transRejoin=a[1]&15,c.ackFrequency=(a[1]&240)>>4,70==b||71==b?c.lowBattery=parseFloat(((a[2]&15)/10+2.5).toFixed(1)):72==b&&(c.lowVoltThreshold=parseFloat(((a[2]&15)/10+2.5).toFixed(1))),c.reserved1=(a[2]&16)>>4,c.heartbeatAckEnable=!!((a[2]&32)>>5),c.operationMode=(a[2]&64)>>6,c.cycleSubBands=!!((a[2]&128)>>7),c.ackRetries=a[3]&7,c.reservedLL=(a[3]&56)>>3,c.ackEnable=
+!!((a[3]&64)>>6),c.heartbeatEnable=!!((a[3]&128)>>7),c.cycleTime=(a[6]&3)<<16|a[5]<<8|a[4],c.backOffReset=(a[6]&252)>>2,c.reservedRD=a[7]&63,c.reserved2=(a[7]&192)>>6,c.resendAttempts=a[8]&15,c.freqSubBand=(a[8]&240)>>4);if(1==c.sequenceNumber){c.timeSyncInterval=a[1];c.joinEUI="";for(b=9;2<=b;b--)c.joinEUI+=a[b].toString(16).toUpperCase().padStart(2,0),2!=b&&(c.joinEUI+="-");c.joinNonceResetEnable=!!(a[10]&1);c.timeSyncWakeupEnable=!!((a[10]&2)>>1);c.reserved1=(a[10]&252)>>2}return c}
 function parseVoboLibVoboSyncConfigurationPayload(a){var b={};b.subgroupID=a[0]&15;b.sequenceNumber=(a[0]&240)>>4;0==b.sequenceNumber&&(b.vbsNodeNumber=a[2]<<8|a[1],b.vbsTimeReference=a.slice(3,7).readUInt32LE(),b.reservedVCPDS=a[7]&15,b.reservedVMPDS=(a[7]&240)>>4,b.reservedVUDS=a[8]&15,b.reserved1=(a[8]&48)>>4,b.reservedVSAE=!!((a[8]&64)>>6),b.vbsEnable=!!((a[8]&128)>>7),b.reserved3=a[9]&63,b.reserved2=(a[9]&192)>>6);1==b.sequenceNumber&&(b.vbsMeasurementDelaySec=a[1]&127,b.reserved1=(a[1]&128)>>
 7,b.vbsUplinkDelaySec=a[2]&127,b.reserved2=(a[2]&128)>>7);return b}
 function parseVoboXXGeneralConfigurationPayload(a){var b={};b.subgroupID=a[0]&15;b.sequenceNumber=(a[0]&240)>>4;b.analogVoltage=parseFloat((a[1]/10).toFixed(1));b.powerTime=parseFloat((a[2]/10).toFixed(1));b.mbEnable=!!(a[3]&1);b.engUnitsEnable=!!(a[3]>>1&1);b.din1TransmitEnable=!!(a[3]>>2&1);b.din2TransmitEnable=!!(a[3]>>3&1);b.din3TransmitEnable=!!(a[3]>>4&1);b.wkupTransmitEnable=!!(a[3]>>5&1);b.ain1TransmitEnable=!!(a[3]>>6&1);b.ain2TransmitEnable=!!(a[3]>>7&1);b.ain3TransmitEnable=!!(a[4]&1);
@@ -110,8 +131,14 @@ function parseVoboTCCalibrationConfigurationPayload(a){var b={};b.subgroupID=a[0
 b.reserved2=(a[4]&128)>>7,b.gain6=parseFloat((((a[6]&7)<<8|a[5])/1E3).toFixed(3)),b.reserved3=(a[6]&248)>>3,b.offset6=parseFloat((((a[8]&127)<<8|a[7])/1E3-10).toFixed(3)),b.reserved4=(a[8]&128)>>7);3==b.sequenceNumber&&(b.gain7=parseFloat((((a[2]&7)<<8|a[1])/1E3).toFixed(3)),b.reserved1=(a[2]&248)>>3,b.offset7=parseFloat((((a[4]&127)<<8|a[3])/1E3-10).toFixed(3)),b.reserved2=(a[4]&128)>>7,b.gain8=parseFloat((((a[6]&7)<<8|a[5])/1E3).toFixed(3)),b.reserved3=(a[6]&248)>>3,b.offset8=parseFloat((((a[8]&
 127)<<8|a[7])/1E3-10).toFixed(3)),b.reserved4=(a[8]&128)>>7);4==b.sequenceNumber&&(b.gain9=parseFloat((((a[2]&7)<<8|a[1])/1E3).toFixed(3)),b.reserved1=(a[2]&248)>>3,b.offset9=parseFloat((((a[4]&127)<<8|a[3])/1E3-10).toFixed(3)),b.reserved2=(a[4]&128)>>7,b.gain10=parseFloat((((a[6]&7)<<8|a[5])/1E3).toFixed(3)),b.reserved3=(a[6]&248)>>3,b.offset10=parseFloat((((a[8]&127)<<8|a[7])/1E3-10).toFixed(3)),b.reserved4=(a[8]&128)>>7);5==b.sequenceNumber&&(b.gain11=parseFloat((((a[2]&7)<<8|a[1])/1E3).toFixed(3)),
 b.reserved1=(a[2]&248)>>3,b.offset11=parseFloat((((a[4]&127)<<8|a[3])/1E3-10).toFixed(3)),b.reserved2=(a[4]&128)>>7,b.gain12=parseFloat((((a[6]&7)<<8|a[5])/1E3).toFixed(3)),b.reserved3=(a[6]&248)>>3,b.offset12=parseFloat((((a[8]&127)<<8|a[7])/1E3-10).toFixed(3)),b.reserved4=(a[8]&128)>>7);return b}
-function parseConfigurationPayload(a,b){var c={},d=a[0]&15;0==d?c=parseVoboLibGeneralConfigurationPayload(a):1==d?c=parseVoboLibVoboSyncConfigurationPayload(a):70==b&&4==d?c=parseVoboXXGeneralConfigurationPayload(a):70==b&&5==d?c=parseVoboXXModbusGeneralConfigurationPayload(a):70!=b||6!=d&&7!=d?70!=b||8!=d&&9!=d&&10!=d?70==b&&11==d?c=parseVoboXXModbusPayloadsSlotsConfigurationPayload(a):70==b&&12==d?c=parseVoboXXEngineeringUnitsConfigurationPayload(a):71==b&&4==d?c=parseVoboTCGeneralConfigurationPayload(a):
-71==b&&5==d&&(c=parseVoboTCCalibrationConfigurationPayload(a)):c=parseVoboXXModbusGroupsConfigurationPayload(a):c=parseVoboXXModbusGroupsEnableConfigurationPayload(a);return c}
+function parseVoboXPGeneralConfigurationPayload(a){var b={};b.subgroupID=a[0]&15;b.sequenceNumber=(a[0]&240)>>4;0==b.sequenceNumber&&(b.analogVoltage=parseFloat((a[1]/10).toFixed(1)),b.powerTime=parseFloat((a[2]/10).toFixed(1)),b.mbEnable=!!(a[3]&1),b.reserved1=a[3]>>1&127,b.reserved2=a[4]&7,b.mbTransmitEnable=!!(a[4]>>3&1),b.ainPayloadType=a[4]>>4&1,b.reservedMAWE=!!(a[4]>>5&1),b.reservedMADE=!!(a[4]>>6&1),b.reservedMAME=!!(a[4]>>7&1),b.reservedDTC=a[6]<<8|a[5]);1==b.sequenceNumber&&(b.stateRLY1=
+a[1]&1,b.stateRLY2=a[1]>>1&1,b.stateRLY3=a[1]>>2&1,b.stateRLY4=a[1]>>3&1,b.reserved1=a[1]>>4&15,b.lorawanClass=a[2]&1,b.contMeasEnable=!!(a[2]>>1&1),b.reservedARDE=!!(a[2]>>2&1),b.pFailWarnEnable=!!(a[2]>>3&1),b.pcntDin1Enable=!!(a[2]>>4&1),b.pcntDin2Enable=!!(a[2]>>5&1),b.reserved2=a[2]>>6&3,b.pcntDin1Type=a[3]&3,b.pcntDin2Type=a[3]>>2&3,b.reserved3=a[3]>>4&15,b.pcntPeriod=a[4]&63,b.reserved4=a[4]>>6&3,b.contMeasCycleTime=a[5]&63,b.reserved5=a[5]>>6&3,b.pFailThreshold=parseFloat((a[6]/10).toFixed(1)),
+b.serialPHY=a[7]&1,b.reserved6=a[7]>>1&7,b.serialProtoRS485=a[7]>>4&1,b.reserved7=a[7]>>5&1,b.serialProtoRS232=a[7]>>6&1,b.reserved8=a[7]>>7&1);return b}
+function parseVoboXPTransmitEncodingConfigurationPayload(a){var b={};b.subgroupID=a[0]&15;b.sequenceNumber=(a[0]&240)>>4;b.txAin1=a[1]&15;b.txAin2=a[1]>>4&15;b.txAin3=a[2]&15;b.txDin1=a[2]>>4&15;b.txDin2=a[3]&15;b.txPcntDin1=a[3]>>4&15;b.txPcntDin2=a[4]&15;b.txWKUP=a[4]>>4&15;b.txTemp=a[5]&15;b.txVoltRLY1=a[5]>>4&15;b.txVoltRLY2=a[6]&15;b.txVoltRLY3=a[6]>>4&15;b.txVoltRLY4=a[7]&15;b.txVoltVIN=a[7]>>4&15;b.txVolt3V3=a[8]&15;b.txVoltVPP=a[8]>>4&15;b.txContMeasPeriod=a[9]&15;b.txContMeasCnt=a[9]>>4&
+1;b.reserved1=a[9]>>5&7;return b}function parseVoboXPRelayPulseConfigurationPayload(a){var b={};b.subgroupID=a[0]&15;b.sequenceNumber=(a[0]&240)>>4;0==b.sequenceNumber?(b.pulseDelayRLY1=a[2]<<8|a[1],b.pulsePeriodRLY1=a[4]<<8|a[3],b.pulseDelayRLY2=a[6]<<8|a[5],b.pulsePeriodRLY2=a[8]<<8|a[7]):1==b.sequenceNumber&&(b.pulseDelayRLY3=a[2]<<8|a[1],b.pulsePeriodRLY3=a[4]<<8|a[3],b.pulseDelayRLY4=a[6]<<8|a[5],b.pulsePeriodRLY4=a[8]<<8|a[7]);return b}
+function parseConfigurationPayload(a,b){var c={},d=a[0]&15;0==d?c=parseVoboLibGeneralConfigurationPayload(a,b):1==d?c=parseVoboLibVoboSyncConfigurationPayload(a):70==b&&4==d?c=parseVoboXXGeneralConfigurationPayload(a):70==b&&5==d?c=parseVoboXXModbusGeneralConfigurationPayload(a):70!=b||6!=d&&7!=d?70!=b||8!=d&&9!=d&&10!=d?70==b&&11==d?c=parseVoboXXModbusPayloadsSlotsConfigurationPayload(a):70==b&&12==d?c=parseVoboXXEngineeringUnitsConfigurationPayload(a):71==b&&4==d?c=parseVoboTCGeneralConfigurationPayload(a):
+71==b&&5==d?c=parseVoboTCCalibrationConfigurationPayload(a):72==b&&4==d?c=parseVoboXPGeneralConfigurationPayload(a):72==b&&5==d?c=parseVoboXXModbusGeneralConfigurationPayload(a):72!=b||6!=d&&7!=d?72!=b||8!=d&&9!=d&&10!=d?72==b&&11==d?c=parseVoboXXModbusPayloadsSlotsConfigurationPayload(a):72==b&&12==d?c=parseVoboXXEngineeringUnitsConfigurationPayload(a):72==b&&13==d?c=parseVoboXPTransmitEncodingConfigurationPayload(a):72==b&&14==d&&(c=parseVoboXPRelayPulseConfigurationPayload(a)):c=parseVoboXXModbusGroupsConfigurationPayload(a):
+c=parseVoboXXModbusGroupsEnableConfigurationPayload(a):c=parseVoboXXModbusGroupsConfigurationPayload(a):c=parseVoboXXModbusGroupsEnableConfigurationPayload(a);return c}
 function parseModbusGenericPayload(a,b){b={};for(var c=a.length,d=0;d<c-1;){var e=a[d]&63;if(0<e){var f=a[d]>>6&3;d++;if(0==f){var g=a[d+1]<<8|a[d];b["group"+e+"register1"]=g;d+=2}else if(1==f)b["group"+e+"register1"]=a[d+1]<<8|a[d],b["group"+e+"register2"]=a[d+3]<<8|a[d+2],d+=4;else if(2==f){f=[];var h=a[d]&127;d++;for(var k=0;k<h;k++)g=a[d+1]<<8|a[d],b["group"+e+"register"+(k+1)]=g,f.push(g),d+=2}else if(3==f){f=[];h=a[d]&127;d++;k=a[d]&127;d++;h-=k;g=Math.floor((c-d)/2);h>g&&(h=g);for(let l=0;l<
 h;l++)g=a[d+1]<<8|a[d],b["group"+e+"register"+(k+l+1)]=g,f.push(g),d+=2}}else break}return b}function parseAnalogInputVariableLengthPayload(a,b){b={};for(var c=[],d=a.length,e=0;e<d;){var f=a.slice(e,e+6);f=parseOneAnalogSensorPayload(f);c.push(f);e+=6}b.ainPayloads=c;b.numOfAinPayloads=c.length;return b}
 function parseModbusStandardVariableLengthPayload(a,b){b={};for(var c={},d=a.length,e=a[d-1],f=0;f<d-1;)c["Modbus"+(e+f/2)]=a[f+1]<<8|a[f],f+=2;b.modbusSlots=c;b.firstSlotNum=e;b.numModbusSlots=(d-1)/2;return b}
@@ -119,8 +146,8 @@ function lookupAnalogSensorName(a,b){var c=[{"Analog Sensor Number":"0","Analog 
 "Analog Sensor Name":"TC2"},{"Analog Sensor Number":"3","Analog Sensor Name":"TC3"},{"Analog Sensor Number":"4","Analog Sensor Name":"TC4"},{"Analog Sensor Number":"5","Analog Sensor Name":"TC5"},{"Analog Sensor Number":"6","Analog Sensor Name":"TC6"},{"Analog Sensor Number":"7","Analog Sensor Name":"TC7"},{"Analog Sensor Number":"8","Analog Sensor Name":"TC8"},{"Analog Sensor Number":"9","Analog Sensor Name":"TC9"},{"Analog Sensor Number":"10","Analog Sensor Name":"TC10"},{"Analog Sensor Number":"11",
 "Analog Sensor Name":"TC11"},{"Analog Sensor Number":"12","Analog Sensor Name":"TC12"},{"Analog Sensor Number":"13","Analog Sensor Name":"Cold Joint Temperature"}],e=[{"Analog Sensor Number":"0","Analog Sensor Name":"3.3V Supply Voltage"},{"Analog Sensor Number":"1","Analog Sensor Name":"AIN1"},{"Analog Sensor Number":"2","Analog Sensor Name":"AIN2"},{"Analog Sensor Number":"3","Analog Sensor Name":"AIN3"},{"Analog Sensor Number":"4","Analog Sensor Name":"DIN1"},{"Analog Sensor Number":"5","Analog Sensor Name":"DIN1 Pulse Count"},
 {"Analog Sensor Number":"6","Analog Sensor Name":"DIN2"},{"Analog Sensor Number":"7","Analog Sensor Name":"DIN2 Pulse Count"},{"Analog Sensor Number":"8","Analog Sensor Name":"RLY1 Voltage"},{"Analog Sensor Number":"9","Analog Sensor Name":"RLY2 Voltage"},{"Analog Sensor Number":"10","Analog Sensor Name":"RLY3 Voltage"},{"Analog Sensor Number":"11","Analog Sensor Name":"RLY4 Voltage"},{"Analog Sensor Number":"12","Analog Sensor Name":"WKUP"},{"Analog Sensor Number":"13","Analog Sensor Name":"VPP Voltage"},
-{"Analog Sensor Number":"14","Analog Sensor Name":"VIN Voltage"},{"Analog Sensor Number":"15","Analog Sensor Name":"ADC Temperature"},{"Analog Sensor Number":"16","Analog Sensor Name":"Cont Meas Period"},{"Analog Sensor Number":"17","Analog Sensor Name":"Cont Meas Count"}];var f=[],g="";if("VoBoXX"==a)f=c;else if("VoBoTC"==a)f=d;else if("VoBoXP"==a)f=e,c=(b&192)>>6,1==c?g="(Max)":2==c?g="(Min)":3==c&&(g="(Avg)"),b&=63;else throw errorMsg=a+' -- Invalid VoBo Type. Use "VoBoXX", "VoBoTC" or "VoBoXP"',
-Error(errorMsg);f=f.find(h=>h["Analog Sensor Number"]==b.toString());if("undefined"==typeof f)return"AnalogSensor"+b.toString();f=f["Analog Sensor Name"];"VoBoXP"==a&&(f=f+" "+g);return f}
+{"Analog Sensor Number":"14","Analog Sensor Name":"VIN Voltage"},{"Analog Sensor Number":"15","Analog Sensor Name":"ADC Temperature"},{"Analog Sensor Number":"16","Analog Sensor Name":"Cont Meas Period"},{"Analog Sensor Number":"17","Analog Sensor Name":"Cont Meas Count"}];var f=[],g="";if("VoBoXX"==a)f=c;else if("VoBoTC"==a)f=d;else if("VoBoXP"==a)f=e,c=(b&192)>>6,1==c?g=" (Max)":2==c?g=" (Min)":3==c&&(g=" (Avg)"),b&=63;else throw errorMsg=a+' -- Invalid VoBo Type. Use "VoBoXX", "VoBoTC" or "VoBoXP"',
+Error(errorMsg);f=f.find(h=>h["Analog Sensor Number"]==b.toString());if("undefined"==typeof f)return"AnalogSensor"+b.toString();f=f["Analog Sensor Name"];"VoBoXP"==a&&(f+=g);return f}
 function lookupDigitalSensorName(a,b){const c=[{"Digital Sensor Number":"0","Digital Sensor Name":"WKUP"},{"Digital Sensor Number":"1","Digital Sensor Name":"DIN1"},{"Digital Sensor Number":"2","Digital Sensor Name":"DIN2"},{"Digital Sensor Number":"3","Digital Sensor Name":"DIN3"}],d=[{"Digital Sensor Number":"0","Digital Sensor Name":"WKUP"}],e=[{"Digital Sensor Number":"0","Digital Sensor Name":"WKUP"},{"Digital Sensor Number":"1","Digital Sensor Name":"DIN1"},{"Digital Sensor Number":"2","Digital Sensor Name":"DIN2"}];
 var f=[];if("VoBoXX"==a)f=c;else if("VoBoTC"==a)f=d;else if("VoBoXP"==a)f=e;else throw errorMsg=a+' -- Invalid VoBo Type. Use "VoBoXX", "VoBoTC" or "VoBoXP"',Error(errorMsg);a=f.find(g=>g["Digital Sensor Number"]==b.toString());return"undefined"==typeof a?"DigitalSensor"+b.toString():a["Digital Sensor Name"]}
 function lookupUnits(a,b){var c="";c=[{"Units Code":"1",Description:"inches of water at 20 degC (68 degF)","Abbreviated Units":"inH2O (20 degC or 68 degF)"},{"Units Code":"2",Description:"inches of mercury at 0 degC (32 degF)","Abbreviated Units":"inHg (20 degC or 68 degF)"},{"Units Code":"3",Description:"feet of water at 20 degC (68 degF)","Abbreviated Units":"ftH2O (20 degC or 68 degF)"},{"Units Code":"4",Description:"millimeters of water at 20 degC (68 degF)","Abbreviated Units":"mmH2O (20 degC or 68 degF)"},
@@ -161,14 +188,14 @@ Description:"gallons per day","Abbreviated Units":"usg/d"},{"Units Code":"236",D
 // exports had to be commented out.
 //===========================================================
 
-const payload_vb = payload.find((x) => x.variable === "payload");
-const fPort_vb = payload.find((x) => x.variable === "port" || x.variable === "fPort")?.value;
+const payload_vb = payload.find((x) => x.variable === "payload_raw" || x.variable === "payload" || x.variable === "data");
+const fPort_vb = payload.find((x) => x.variable === "port" || x.variable === "fPort" || x.variable === "fport" || x.variable === "FPort")?.value;
 
 if (payload_vb) {
     try {
         const buffer = Buffer.from(payload_vb.value, "hex")
         const decoded = toTagoFormat(buffer, fPort_vb);
-        payload = decoded;
+        payload = payload.concat(decoded);
     } catch (error) {
         console.error(error);
         payload = [{ variable: "parse_error", value: error.message }];

--- a/decoders/connector/volley-boast/vobo-gp-1/v1.0.0/payload.js
+++ b/decoders/connector/volley-boast/vobo-gp-1/v1.0.0/payload.js
@@ -12,7 +12,7 @@ function customDecoder(bytes, fport) {
             {
             variable: decoded.data.analogSensorString0,
             value: decoded.data.sensorData0,
-            units: decoded.data.engUnitsString0
+            unit: decoded.data.engUnitsString0
             }
         ];
         tagoDecoded.push(
@@ -26,12 +26,12 @@ function customDecoder(bytes, fport) {
             {
                 variable: decoded.data.analogSensorString0,
                 value: decoded.data.sensorData0,
-                units: decoded.data.engUnitsString0
+                unit: decoded.data.engUnitsString0
             },
             {
                 variable: decoded.data.analogSensorString1,
                 value: decoded.data.sensorData1,
-                units: decoded.data.engUnitsString1
+                unit: decoded.data.engUnitsString1
             }
         ];
         tagoDecoded.push(
@@ -55,7 +55,7 @@ function customDecoder(bytes, fport) {
         var tagoDecoded = decoded.data.ainPayloads.map((payloadObj, index) => ({
             variable: decoded.data[`analogSensorString${index}`],
             value: payloadObj.sensorData0,
-            units: decoded.data[`engUnitsString${index}`]
+            unit: decoded.data[`engUnitsString${index}`]
         }));
         tagoDecoded.push(
             { variable: "fport", value: decoded.data.fport },

--- a/decoders/connector/volley-boast/vobo-gp-1/v1.0.0/payload.test.ts
+++ b/decoders/connector/volley-boast/vobo-gp-1/v1.0.0/payload.test.ts
@@ -34,22 +34,38 @@ describe(`fPort: ${testPayloads.data[0].fport} - ${testPayloads.data[0].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const din1 = payload.find((item) => item.variable === 'DIN1');
+    const din2 = payload.find((item) => item.variable === 'DIN2');
+    const din3 = payload.find((item) => item.variable === 'DIN3');
+    const wkup = payload.find((item) => item.variable === 'WKUP');
+    const adc1 = payload.find((item) => item.variable === 'ADC1');
+    const adc2 = payload.find((item) => item.variable === 'ADC2');
+    const adc3 = payload.find((item) => item.variable === 'ADC3');
+    const battery = payload.find((item) => item.variable === 'Battery');
+    const temperature = payload.find((item) => item.variable === 'Temperature');
+    const modbus0 = payload.find((item) => item.variable === 'Modbus0');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+    
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'DIN1', value: 1 },
-            { variable: 'DIN2', value: 1 },
-            { variable: 'DIN3', value: 1 },
-            { variable: 'WKUP', value: 0 },
-            { variable: 'ADC1', value: 994 },
-            { variable: 'ADC2', value: 1009 },
-            { variable: 'ADC3', value: 1603 },
-            { variable: 'Battery', value: 3528 },
-            { variable: 'Temperature', value: 25.75 },
-            { variable: 'Modbus0', value: 0 },
-            { variable: 'fport', value: 1 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Standard' }
-        ]);
+        expect(din1.value).toBe(1);
+        expect(din2.value).toBe(1);
+        expect(din3.value).toBe(1);
+        expect(wkup.value).toBe(0);
+        expect(adc1.value).toBe(994);
+        expect(adc2.value).toBe(1009);
+        expect(adc3.value).toBe(1603);
+        expect(battery.value).toBe(3528);
+        expect(temperature.value).toBe(25.75);
+        expect(modbus0.value).toBe(0);
+        expect(fport.value).toBe(1);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Standard');
     });
 });
 
@@ -61,17 +77,28 @@ describe(`fPort: ${testPayloads.data[1].fport} - ${testPayloads.data[1].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const modbus1 = payload.find((item) => item.variable === 'Modbus1');
+    const modbus2 = payload.find((item) => item.variable === 'Modbus2');
+    const modbus3 = payload.find((item) => item.variable === 'Modbus3');
+    const modbus4 = payload.find((item) => item.variable === 'Modbus4');
+    const modbus5 = payload.find((item) => item.variable === 'Modbus5');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'Modbus1', value: 8705 },
-            { variable: 'Modbus2', value: 8706 },
-            { variable: 'Modbus3', value: 8707 },
-            { variable: 'Modbus4', value: 8708 },
-            { variable: 'Modbus5', value: 8709 },
-            { variable: 'fport', value: 2 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Modbus Standard' }
-        ]);
+        expect(modbus1.value).toBe(8705);
+        expect(modbus2.value).toBe(8706);
+        expect(modbus3.value).toBe(8707);
+        expect(modbus4.value).toBe(8708);
+        expect(modbus5.value).toBe(8709);
+        expect(fport.value).toBe(2);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Modbus Standard');
     });
 });
 
@@ -83,17 +110,28 @@ describe(`fPort: ${testPayloads.data[2].fport} - ${testPayloads.data[2].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const modbus6 = payload.find((item) => item.variable === 'Modbus6');
+    const modbus7 = payload.find((item) => item.variable === 'Modbus7');
+    const modbus8 = payload.find((item) => item.variable === 'Modbus8');
+    const modbus9 = payload.find((item) => item.variable === 'Modbus9');
+    const modbus10 = payload.find((item) => item.variable === 'Modbus10');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'Modbus6', value: 8705 },
-            { variable: 'Modbus7', value: 8706 },
-            { variable: 'Modbus8', value: 8707 },
-            { variable: 'Modbus9', value: 8708 },
-            { variable: 'Modbus10', value: 8709 },
-            { variable: 'fport', value: 3 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Modbus Standard' }
-        ]);
+        expect(modbus6.value).toBe(8705);
+        expect(modbus7.value).toBe(8706);
+        expect(modbus8.value).toBe(8707);
+        expect(modbus9.value).toBe(8708);
+        expect(modbus10.value).toBe(8709);
+        expect(fport.value).toBe(3);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Modbus Standard');
     });
 });
 
@@ -105,17 +143,28 @@ describe(`fPort: ${testPayloads.data[3].fport} - ${testPayloads.data[3].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const modbus11 = payload.find((item) => item.variable === 'Modbus11');
+    const modbus12 = payload.find((item) => item.variable === 'Modbus12');
+    const modbus13 = payload.find((item) => item.variable === 'Modbus13');
+    const modbus14 = payload.find((item) => item.variable === 'Modbus14');
+    const modbus15 = payload.find((item) => item.variable === 'Modbus15');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'Modbus11', value: 8705 },
-            { variable: 'Modbus12', value: 8706 },
-            { variable: 'Modbus13', value: 8707 },
-            { variable: 'Modbus14', value: 8708 },
-            { variable: 'Modbus15', value: 8709 },
-            { variable: 'fport', value: 4 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Modbus Standard' }
-        ]);
+        expect(modbus11.value).toBe(8705);
+        expect(modbus12.value).toBe(8706);
+        expect(modbus13.value).toBe(8707);
+        expect(modbus14.value).toBe(8708);
+        expect(modbus15.value).toBe(8709);
+        expect(fport.value).toBe(4);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Modbus Standard');
     });
 });
 
@@ -127,17 +176,28 @@ describe(`fPort: ${testPayloads.data[4].fport} - ${testPayloads.data[4].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const modbus16 = payload.find((item) => item.variable === 'Modbus16');
+    const modbus17 = payload.find((item) => item.variable === 'Modbus17');
+    const modbus18 = payload.find((item) => item.variable === 'Modbus18');
+    const modbus19 = payload.find((item) => item.variable === 'Modbus19');
+    const modbus20 = payload.find((item) => item.variable === 'Modbus20');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'Modbus16', value: 8705 },
-            { variable: 'Modbus17', value: 8706 },
-            { variable: 'Modbus18', value: 8707 },
-            { variable: 'Modbus19', value: 8708 },
-            { variable: 'Modbus20', value: 8709 },
-            { variable: 'fport', value: 5 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Modbus Standard' }
-        ]);
+        expect(modbus16.value).toBe(8705);
+        expect(modbus17.value).toBe(8706);
+        expect(modbus18.value).toBe(8707);
+        expect(modbus19.value).toBe(8708);
+        expect(modbus20.value).toBe(8709);
+        expect(fport.value).toBe(5);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Modbus Standard');
     });
 });
 
@@ -149,17 +209,28 @@ describe(`fPort: ${testPayloads.data[5].fport} - ${testPayloads.data[5].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const modbus21 = payload.find((item) => item.variable === 'Modbus21');
+    const modbus22 = payload.find((item) => item.variable === 'Modbus22');
+    const modbus23 = payload.find((item) => item.variable === 'Modbus23');
+    const modbus24 = payload.find((item) => item.variable === 'Modbus24');
+    const modbus25 = payload.find((item) => item.variable === 'Modbus25');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'Modbus21', value: 8705 },
-            { variable: 'Modbus22', value: 8706 },
-            { variable: 'Modbus23', value: 8707 },
-            { variable: 'Modbus24', value: 8708 },
-            { variable: 'Modbus25', value: 8709 },
-            { variable: 'fport', value: 6 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Modbus Standard' }
-        ]);
+        expect(modbus21.value).toBe(8705);
+        expect(modbus22.value).toBe(8706);
+        expect(modbus23.value).toBe(8707);
+        expect(modbus24.value).toBe(8708);
+        expect(modbus25.value).toBe(8709);
+        expect(fport.value).toBe(6);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Modbus Standard');
     });
 });
 
@@ -171,17 +242,28 @@ describe(`fPort: ${testPayloads.data[6].fport} - ${testPayloads.data[6].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const modbus26 = payload.find((item) => item.variable === 'Modbus26');
+    const modbus27 = payload.find((item) => item.variable === 'Modbus27');
+    const modbus28 = payload.find((item) => item.variable === 'Modbus28');
+    const modbus29 = payload.find((item) => item.variable === 'Modbus29');
+    const modbus30 = payload.find((item) => item.variable === 'Modbus30');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'Modbus26', value: 8705 },
-            { variable: 'Modbus27', value: 8706 },
-            { variable: 'Modbus28', value: 8707 },
-            { variable: 'Modbus29', value: 8708 },
-            { variable: 'Modbus30', value: 8709 },
-            { variable: 'fport', value: 7 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Modbus Standard' }
-        ]);
+        expect(modbus26.value).toBe(8705);
+        expect(modbus27.value).toBe(8706);
+        expect(modbus28.value).toBe(8707);
+        expect(modbus29.value).toBe(8708);
+        expect(modbus30.value).toBe(8709);
+        expect(fport.value).toBe(7);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Modbus Standard');
     });
 });
 
@@ -193,17 +275,28 @@ describe(`fPort: ${testPayloads.data[7].fport} - ${testPayloads.data[7].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const modbus31 = payload.find((item) => item.variable === 'Modbus31');
+    const modbus32 = payload.find((item) => item.variable === 'Modbus32');
+    const modbus33 = payload.find((item) => item.variable === 'Modbus33');
+    const modbus34 = payload.find((item) => item.variable === 'Modbus34');
+    const modbus35 = payload.find((item) => item.variable === 'Modbus35');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'Modbus31', value: 8705 },
-            { variable: 'Modbus32', value: 8706 },
-            { variable: 'Modbus33', value: 8707 },
-            { variable: 'Modbus34', value: 8708 },
-            { variable: 'Modbus35', value: 8709 },
-            { variable: 'fport', value: 8 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Modbus Standard' }
-        ]);
+        expect(modbus31.value).toBe(8705);
+        expect(modbus32.value).toBe(8706);
+        expect(modbus33.value).toBe(8707);
+        expect(modbus34.value).toBe(8708);
+        expect(modbus35.value).toBe(8709);
+        expect(fport.value).toBe(8);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Modbus Standard');
     });
 });
 
@@ -215,17 +308,28 @@ describe(`fPort: ${testPayloads.data[8].fport} - ${testPayloads.data[8].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const modbus36 = payload.find((item) => item.variable === 'Modbus36');
+    const modbus37 = payload.find((item) => item.variable === 'Modbus37');
+    const modbus38 = payload.find((item) => item.variable === 'Modbus38');
+    const modbus39 = payload.find((item) => item.variable === 'Modbus39');
+    const modbus40 = payload.find((item) => item.variable === 'Modbus40');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'Modbus36', value: 8705 },
-            { variable: 'Modbus37', value: 8706 },
-            { variable: 'Modbus38', value: 8707 },
-            { variable: 'Modbus39', value: 8708 },
-            { variable: 'Modbus40', value: 8709 },
-            { variable: 'fport', value: 9 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Modbus Standard' }
-        ]);
+        expect(modbus36.value).toBe(8705);
+        expect(modbus37.value).toBe(8706);
+        expect(modbus38.value).toBe(8707);
+        expect(modbus39.value).toBe(8708);
+        expect(modbus40.value).toBe(8709);
+        expect(fport.value).toBe(9);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Modbus Standard');
     });
 });
 
@@ -237,26 +341,45 @@ describe(`fPort: ${testPayloads.data[9].fport} - ${testPayloads.data[9].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const batteryLevel = payload.find((item) => item.variable === 'batteryLevel');
+    const fatalErrorsTotal = payload.find((item) => item.variable === 'fatalErrorsTotal');
+    const rssiAvg = payload.find((item) => item.variable === 'rssiAvg');
+    const failedJoinAttemptsTotal = payload.find((item) => item.variable === 'failedJoinAttemptsTotal');
+    const configUpdateOccurred = payload.find((item) => item.variable === 'configUpdateOccurred');
+    const firmwareRevision = payload.find((item) => item.variable === 'firmwareRevision');
+    const rebootsTotal = payload.find((item) => item.variable === 'rebootsTotal');
+    const failedTransmitsTotal = payload.find((item) => item.variable === 'failedTransmitsTotal');
+    const errorEventLogsTotal = payload.find((item) => item.variable === 'errorEventLogsTotal');
+    const warningEventLogsTotal = payload.find((item) => item.variable === 'warningEventLogsTotal');
+    const infoEventLogsTotal = payload.find((item) => item.variable === 'infoEventLogsTotal');
+    const measurementPacketsTotal = payload.find((item) => item.variable === 'measurementPacketsTotal');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'batteryLevel', value: 3532 },
-            { variable: 'fatalErrorsTotal', value: 0 },
-            { variable: 'rssiAvg', value: 57 },
-            { variable: 'failedJoinAttemptsTotal', value: 0 },
-            { variable: 'configUpdateOccurred', value: 0 },
-            { variable: 'firmwareRevision', value: 0 },
-            { variable: 'rebootsTotal', value: 3 },
-            { variable: 'failedTransmitsTotal', value: 0 },
-            { variable: 'errorEventLogsTotal', value: 0 },
-            { variable: 'warningEventLogsTotal', value: 0 },
-            { variable: 'infoEventLogsTotal', value: 0 },
-            { variable: 'measurementPacketsTotal', value: 4 },
-            { variable: 'fport', value: 20 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Heartbeat 2.0' }
-        ]);
+        expect(batteryLevel.value).toBe(3532);
+        expect(fatalErrorsTotal.value).toBe(0);
+        expect(rssiAvg.value).toBe(57);
+        expect(failedJoinAttemptsTotal.value).toBe(0);
+        expect(configUpdateOccurred.value).toBe(0);
+        expect(firmwareRevision.value).toBe(0);
+        expect(rebootsTotal.value).toBe(3);
+        expect(failedTransmitsTotal.value).toBe(0);
+        expect(errorEventLogsTotal.value).toBe(0);
+        expect(warningEventLogsTotal.value).toBe(0);
+        expect(infoEventLogsTotal.value).toBe(0);
+        expect(measurementPacketsTotal.value).toBe(4);
+        expect(fport.value).toBe(20);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Heartbeat 2.0');
     });
 });
+
 describe(`fPort: ${testPayloads.data[10].fport} - ${testPayloads.data[10].name}`, () => { // fPort 30
     const raw_payload = [
         { variable: "payload", value: testPayloads.data[10].payload },
@@ -265,8 +388,22 @@ describe(`fPort: ${testPayloads.data[10].fport} - ${testPayloads.data[10].name}`
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+
+    const adcTemperature = payload.find((item) => item.variable === 'ADC Temperature');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual({ variable: 'ADC Temperature', value: 26.375, units: 'C' });
+        expect(adcTemperature.value).toBe(26.375);
+        expect(adcTemperature.units).toBe("C")
+        expect(fport.value).toBe(30);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('One Analog Input');
     });
 });
 
@@ -278,11 +415,25 @@ describe(`fPort: ${testPayloads.data[11].fport} - ${testPayloads.data[11].name}`
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+
+    const ain1 = payload.find((item) => item.variable === 'AIN1');
+    const ain2 = payload.find((item) => item.variable === 'AIN2');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'AIN1', value: 9.999750137329102, units: 'mA' },
-            { variable: 'AIN2', value: 2.5325000286102295, units: 'V' }
-        ]);
+        expect(ain1.value).toBe(9.999750137329102);
+        expect(ain1.units).toBe('mA');
+        expect(ain2.value).toBe(2.5325000286102295);
+        expect(ain2.units).toBe('V');
+        expect(fport.value).toBe(40);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Two Analog Inputs');
     });
 });
 
@@ -294,16 +445,26 @@ describe(`fPort: ${testPayloads.data[12].fport} - ${testPayloads.data[12].name}`
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const wkup = payload.find((item) => item.variable === 'WKUP');
+    const din1 = payload.find((item) => item.variable === 'DIN1');
+    const din2 = payload.find((item) => item.variable === 'DIN2');
+    const din3 = payload.find((item) => item.variable === 'DIN3');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'WKUP', value: 0 },
-            { variable: 'DIN1', value: 1 },
-            { variable: 'DIN2', value: 1 },
-            { variable: 'DIN3', value: 1 },
-            { variable: 'fport', value: 50 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Digital Inputs' }
-        ]);
+        expect(wkup.value).toBe(0);
+        expect(din1.value).toBe(1);
+        expect(din2.value).toBe(1);
+        expect(din3.value).toBe(1);
+        expect(fport.value).toBe(50);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Digital Inputs');
     });
 });
 
@@ -315,15 +476,24 @@ describe(`fPort: ${testPayloads.data[13].fport} - ${testPayloads.data[13].name}`
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const eventTimestamp = payload.find((item) => item.variable === 'eventTimestamp');
+    const eventCode = payload.find((item) => item.variable === 'eventCode');
+    const metadata = payload.find((item) => item.variable === 'metadata');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'eventTimestamp', value: 1690115688 },
-            { variable: 'eventCode', value: 65535 },
-            { variable: 'metadata', value: [0, 0, 0, 0, 0] },
-            { variable: 'fport', value: 60 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Event Log' }
-        ]);
+        expect(eventTimestamp.value).toBe(1690115688);
+        expect(eventCode.value).toBe(65535);
+        expect(metadata.value).toStrictEqual([0, 0, 0, 0, 0]);
+        expect(fport.value).toBe(60);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Event Log');
     });
 });
 
@@ -335,31 +505,56 @@ describe(`fPort: ${testPayloads.data[14].fport} - ${testPayloads.data[14].name}`
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const subgroupID = payload.find((item) => item.variable === 'subgroupID');
+    const sequenceNumber = payload.find((item) => item.variable === 'sequenceNumber');
+    const transRejoin = payload.find((item) => item.variable === 'transRejoin');
+    const ackFrequency = payload.find((item) => item.variable === 'ackFrequency');
+    const lowBattery = payload.find((item) => item.variable === 'lowBattery');
+    const reserved1 = payload.find((item) => item.variable === 'reserved1');
+    const heartbeatAckEnable = payload.find((item) => item.variable === 'heartbeatAckEnable');
+    const operationMode = payload.find((item) => item.variable === 'operationMode');
+    const cycleSubBands = payload.find((item) => item.variable === 'cycleSubBands');
+    const ackRetries = payload.find((item) => item.variable === 'ackRetries');
+    const reservedLL = payload.find((item) => item.variable === 'reservedLL');
+    const ackEnable = payload.find((item) => item.variable === 'ackEnable');
+    const heartbeatEnable = payload.find((item) => item.variable === 'heartbeatEnable');
+    const cycleTime = payload.find((item) => item.variable === 'cycleTime');
+    const backOffReset = payload.find((item) => item.variable === 'backOffReset');
+    const reservedRD = payload.find((item) => item.variable === 'reservedRD');
+    const reserved2 = payload.find((item) => item.variable === 'reserved2');
+    const resendAttempts = payload.find((item) => item.variable === 'resendAttempts');
+    const freqSubBand = payload.find((item) => item.variable === 'freqSubBand');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'subgroupID', value: 0 },
-            { variable: 'sequenceNumber', value: 0 },
-            { variable: 'transRejoin', value: 10 },
-            { variable: 'ackFrequency', value: 4 },
-            { variable: 'lowBattery', value: 3.1 },
-            { variable: 'reserved1', value: 0 },
-            { variable: 'heartbeatAckEnable', value: true },
-            { variable: 'operationMode', value: 1 },
-            { variable: 'cycleSubBands', value: true },
-            { variable: 'ackRetries', value: 2 },
-            { variable: 'reservedLL', value: 4 },
-            { variable: 'ackEnable', value: true },
-            { variable: 'heartbeatEnable', value: true },
-            { variable: 'cycleTime', value: 60 },
-            { variable: 'backOffReset', value: 9 },
-            { variable: 'reservedRD', value: 5 },
-            { variable: 'reserved2', value: 0 },
-            { variable: 'resendAttempts', value: 0 },
-            { variable: 'freqSubBand', value: 2 },
-            { variable: 'fport', value: 70 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Configuration' }
-        ]);
+        expect(subgroupID.value).toBe(0);
+        expect(sequenceNumber.value).toBe(0);
+        expect(transRejoin.value).toBe(10);
+        expect(ackFrequency.value).toBe(4);
+        expect(lowBattery.value).toBe(3.1);
+        expect(reserved1.value).toBe(0);
+        expect(heartbeatAckEnable.value).toBe(true);
+        expect(operationMode.value).toBe(1);
+        expect(cycleSubBands.value).toBe(true);
+        expect(ackRetries.value).toBe(2);
+        expect(reservedLL.value).toBe(4);
+        expect(ackEnable.value).toBe(true);
+        expect(heartbeatEnable.value).toBe(true);
+        expect(cycleTime.value).toBe(60);
+        expect(backOffReset.value).toBe(9);
+        expect(reservedRD.value).toBe(5);
+        expect(reserved2.value).toBe(0);
+        expect(resendAttempts.value).toBe(0);
+        expect(freqSubBand.value).toBe(2);
+        expect(fport.value).toBe(70);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Configuration');
     });
 });
 
@@ -371,13 +566,20 @@ describe(`fPort: ${testPayloads.data[15].fport} - ${testPayloads.data[15].name}`
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const group3register1 = payload.find((item) => item.variable === 'group3register1');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'group3register1', value: 531 },
-            { variable: 'fport', value: 100 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Modbus Generic' }
-        ]);
+        expect(group3register1.value).toBe(531);
+        expect(fport.value).toBe(100);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Modbus Generic');
     });
 });
 
@@ -390,14 +592,27 @@ describe(`fPort: ${testPayloads.data[16].fport} - ${testPayloads.data[16].name}`
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const ain1 = payload.find((item) => item.variable === 'AIN1');
+    const ain2 = payload.find((item) => item.variable === 'AIN2');
+    const ain3 = payload.find((item) => item.variable === 'AIN3');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'AIN1', value: 1, units: 'ADC code' },
-            { variable: 'AIN2', value: 2, units: 'ADC code' },
-            { variable: 'AIN3', value: 1, units: 'ADC code' },
-            { variable: 'Battery Voltage', value: 3.375999927520752, units: 'V' },
-            { variable: 'ADC Temperature', value: 22.75, units: 'C' }
-        ]);
+        expect(ain1.value).toBe(1);
+        expect(ain1.units).toBe('ADC code');
+        expect(ain2.value).toBe(2);
+        expect(ain2.units).toBe('ADC code');
+        expect(ain3.value).toBe(1);
+        expect(ain3.units).toBe('ADC code');
+        expect(fport.value).toBe(110);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Analog Input Variable Length');
     });
 });
 
@@ -409,16 +624,32 @@ describe(`fPort: ${testPayloads.data[17].fport} - ${testPayloads.data[17].name}`
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const modbus1 = payload.find((item) => item.variable === 'Modbus1');
+    const modbus2 = payload.find((item) => item.variable === 'Modbus2');
+    const modbus3 = payload.find((item) => item.variable === 'Modbus3');
+    const modbus4 = payload.find((item) => item.variable === 'Modbus4');
+    const modbus5 = payload.find((item) => item.variable === 'Modbus5');
+    const modbus6 = payload.find((item) => item.variable === 'Modbus6');
+    const modbus7 = payload.find((item) => item.variable === 'Modbus7');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'Modbus1', value: 9999 },
-            { variable: 'Modbus2', value: 9999 },
-            { variable: 'Modbus3', value: 9999 },
-            { variable: 'Modbus4', value: 9999 },
-            { variable: 'Modbus5', value: 9999 },
-            { variable: 'Modbus6', value: 9999 },
-            { variable: 'Modbus7', value: 9999 }
-        ]);
+        expect(modbus1.value).toBe(9999);
+        expect(modbus2.value).toBe(9999);        
+        expect(modbus3.value).toBe(9999);
+        expect(modbus4.value).toBe(9999);
+        expect(modbus5.value).toBe(9999);
+        expect(modbus6.value).toBe(9999);
+        expect(modbus7.value).toBe(9999);
+        expect(fport.value).toBe(120);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Modbus Standard Variable Length');
     });
 });
 

--- a/decoders/connector/volley-boast/vobo-gp-1/v1.0.0/payload.test.ts
+++ b/decoders/connector/volley-boast/vobo-gp-1/v1.0.0/payload.test.ts
@@ -400,7 +400,7 @@ describe(`fPort: ${testPayloads.data[10].fport} - ${testPayloads.data[10].name}`
 
     test("Check if data is correct", () => {
         expect(adcTemperature.value).toBe(26.375);
-        expect(adcTemperature.units).toBe("C")
+        expect(adcTemperature.unit).toBe("C")
         expect(fport.value).toBe(30);
         expect(voboType.value).toBe('VoBoXX');
         expect(payloadType.value).toBe('One Analog Input');
@@ -428,9 +428,9 @@ describe(`fPort: ${testPayloads.data[11].fport} - ${testPayloads.data[11].name}`
 
     test("Check if data is correct", () => {
         expect(ain1.value).toBe(9.999750137329102);
-        expect(ain1.units).toBe('mA');
+        expect(ain1.unit).toBe('mA');
         expect(ain2.value).toBe(2.5325000286102295);
-        expect(ain2.units).toBe('V');
+        expect(ain2.unit).toBe('V');
         expect(fport.value).toBe(40);
         expect(voboType.value).toBe('VoBoXX');
         expect(payloadType.value).toBe('Two Analog Inputs');
@@ -605,11 +605,11 @@ describe(`fPort: ${testPayloads.data[16].fport} - ${testPayloads.data[16].name}`
 
     test("Check if data is correct", () => {
         expect(ain1.value).toBe(1);
-        expect(ain1.units).toBe('ADC code');
+        expect(ain1.unit).toBe('ADC code');
         expect(ain2.value).toBe(2);
-        expect(ain2.units).toBe('ADC code');
+        expect(ain2.unit).toBe('ADC code');
         expect(ain3.value).toBe(1);
-        expect(ain3.units).toBe('ADC code');
+        expect(ain3.unit).toBe('ADC code');
         expect(fport.value).toBe(110);
         expect(voboType.value).toBe('VoBoXX');
         expect(payloadType.value).toBe('Analog Input Variable Length');

--- a/decoders/connector/volley-boast/vobo-hl-1/v1.0.0/payload.js
+++ b/decoders/connector/volley-boast/vobo-hl-1/v1.0.0/payload.js
@@ -8,11 +8,18 @@ function customDecoder(bytes, fport) {
     //=======================================================
     // Insert your customization here
     if (fport == 30) {
-        var tagoDecoded = {
+        var tagoDecoded = [
+            {
             variable: decoded.data.analogSensorString0,
             value: decoded.data.sensorData0,
             units: decoded.data.engUnitsString0
-        }
+            }
+        ];
+        tagoDecoded.push(
+            { variable: "fport", value: decoded.data.fport },
+            { variable: "voboType", value: decoded.data.voboType },
+            { variable: "payloadType", value: decoded.data.payloadType }
+        );
     }
     else if (fport == 40) {
         var tagoDecoded = [
@@ -26,14 +33,18 @@ function customDecoder(bytes, fport) {
                 value: decoded.data.sensorData1,
                 units: decoded.data.engUnitsString1
             }
-        ]
+        ];
+        tagoDecoded.push(
+            { variable: "fport", value: decoded.data.fport },
+            { variable: "voboType", value: decoded.data.voboType },
+            { variable: "payloadType", value: decoded.data.payloadType }
+        );
     }
     else if (fport == 50) {
         var tagoDecoded = decoded.data.digitalSensorStrings.map((sensor, index) => ({
             variable: sensor,
             value: decoded.data.digitalSensorData[index]
         }));
-
         tagoDecoded.push(
             { variable: "fport", value: decoded.data.fport },
             { variable: "voboType", value: decoded.data.voboType },
@@ -46,12 +57,22 @@ function customDecoder(bytes, fport) {
             value: payloadObj.sensorData0,
             units: decoded.data[`engUnitsString${index}`]
         }));
+        tagoDecoded.push(
+            { variable: "fport", value: decoded.data.fport },
+            { variable: "voboType", value: decoded.data.voboType },
+            { variable: "payloadType", value: decoded.data.payloadType }
+        );
     }
     else if (fport == 120) {
         var tagoDecoded = Object.entries(decoded.data.modbusSlots).map(([key, value]) => ({
             variable: key,
             value: value
         }));
+        tagoDecoded.push(
+            { variable: "fport", value: decoded.data.fport },
+            { variable: "voboType", value: decoded.data.voboType },
+            { variable: "payloadType", value: decoded.data.payloadType }
+        );
     }
     else {
         var tagoDecoded = Object.entries(decoded.data).map(([key, value]) => ({
@@ -63,13 +84,13 @@ function customDecoder(bytes, fport) {
     return tagoDecoded;
 }
 
-const DECODER_MAJOR_VERSION=2,DECODER_MINOR_VERSION=1,DECODER_PATCH_VERSION=1;function decodeUplink(a){return Decoder(a.bytes,a.fPort)}
-function Decoder(a,b){var c={},d=[];1==b?c=parseStandardPayload(a):2<=b&&9>=b?c=parseModbusStandardPayload(a,b):10==b?c=parseHeartbeat1p0Payload(a):20<=b&&29>=b?c=parseHeartbeat2p0Payload(a):30<=b&&39>=b?c=parseOneAnalogSensorPayload(a):40<=b&&49>=b?c=parseTwoAnalogSensorsPayload(a):50<=b&&59>=b?c=parseDigitalSensorsPayload(a):60<=b&&69>=b?c=parseEventLogPayload(a):70<=b&&79>=b?c=parseConfigurationPayload(a,b):100<=b&&109>=b?c=parseModbusGenericPayload(a,b):110<=b&&119>=b?c=parseAnalogInputVariableLengthPayload(a,
-b):120<=b&&129>=b?c=parseModbusStandardVariableLengthPayload(a,b):d.push("unknown FPort");a=addVoboMetadata(c,b);a.warnings=[];a.errors=d;return a}
+const DECODER_MAJOR_VERSION=2,DECODER_MINOR_VERSION=2,DECODER_PATCH_VERSION=0;function decodeUplink(a){return Decoder(a.bytes,a.fPort)}
+function Decoder(a,b){var c={},d=[];1==b?c=parseStandardPayload(a):2<=b&&9>=b?c=parseModbusStandardPayload(a,b):10==b?c=parseHeartbeat1p0Payload(a):20<=b&&29>=b?c=parseHeartbeat2p0Payload(a):30<=b&&39>=b?c=parseOneAnalogSensorPayload(a):40<=b&&49>=b?c=parseTwoAnalogSensorsPayload(a):50<=b&&59>=b?c=parseDigitalSensorsPayload(a):60<=b&&69>=b?c=parseEventLogPayload(a):70<=b&&79>=b?c=parseConfigurationPayload(a,b):80<=b&&89>=b?c=parseEventLogPayload(a):100<=b&&109>=b?c=parseModbusGenericPayload(a,b):
+110<=b&&119>=b?c=parseAnalogInputVariableLengthPayload(a,b):120<=b&&129>=b?c=parseModbusStandardVariableLengthPayload(a,b):d.push("unknown FPort");a=addVoboMetadata(c,b);a.warnings=[];a.errors=d;return a}
 function addVoboMetadata(a,b){var c={};c.data=a;var d=a="",e=b%10;0==e||1<=b&&10>b?a="VoBoXX":1==e?a="VoBoTC":2==e&&(a="VoBoXP");if(1==b)d="Standard";else if(2<=b&&9>=b)d="Modbus Standard";else if(10==b)d="Heartbeat 1.0";else if(20<=b&&29>=b)d="Heartbeat 2.0";else if(30<=b&&39>=b)d="One Analog Input",c.data.analogSensorString0=lookupAnalogSensorName(a,c.data.sensorNum0),c.data.engUnitsString0=lookupUnits(1,c.data.sensorUnits0);else if(40<=b&&49>=b)d="Two Analog Inputs",c.data.analogSensorString0=
 lookupAnalogSensorName(a,c.data.sensorNum0),c.data.engUnitsString0=lookupUnits(1,c.data.sensorUnits0),c.data.analogSensorString1=lookupAnalogSensorName(a,c.data.sensorNum1),c.data.engUnitsString1=lookupUnits(1,c.data.sensorUnits1);else if(50<=b&&59>=b)for(d="Digital Inputs",c.data.digitalSensorStrings=[],c.data.digitalSensorData=[],e=0;16>e;e++)1==(c.data.sensorValid0>>e&1)&&(c.data.digitalSensorStrings.push(lookupDigitalSensorName(a,e)),c.data.digitalSensorData.push(c.data.sensorData0>>e&1));else if(60<=
-b&&69>=b)d="Event Log";else if(70<=b&&79>=b)d="Configuration";else if(100<=b&&109>=b)d="Modbus Generic";else if(110<=b&&119>=b)for(d="Analog Input Variable Length",e=0;e<c.data.numOfAinPayloads;e++)c.data["analogSensorString"+e]=lookupAnalogSensorName(a,c.data.ainPayloads[e].sensorNum0),c.data["engUnitsString"+e]=lookupUnits(1,c.data.ainPayloads[e].sensorUnits0);else 120<=b&&129>=b&&(d="Modbus Standard Variable Length");c.data.fport=b;c.data.voboType=a;c.data.payloadType=d;return c}
-function parseStandardPayload(a){var b={};b.DIN1=a[0]&1;b.DIN2=a[0]>>1&1;b.DIN3=a[0]>>2&1;b.WKUP=a[0]>>3&1;b.ADC1=(a[0]&240)>>4|a[1]<<4;b.ADC2=(a[3]&15)<<8|a[2];b.ADC3=(a[3]&240)>>4|a[4]<<4;b.Battery=4*((a[6]&15)<<8|a[5]);b.Temperature=0==(a[7]>>7&1)?.125*((a[6]&240)>>4|a[7]<<4):-.125*(4096-((a[6]&240)>>4|a[7]<<4));b.Modbus0=a[9]<<8|a[8];return b}
+b&&69>=b)d="Event Log";else if(70<=b&&79>=b)d="Configuration";else if(80<=b&&89>=b)d="Notification";else if(100<=b&&109>=b)d="Modbus Generic";else if(110<=b&&119>=b)for(d="Analog Input Variable Length",e=0;e<c.data.numOfAinPayloads;e++)c.data["analogSensorString"+e]=lookupAnalogSensorName(a,c.data.ainPayloads[e].sensorNum0),c.data["engUnitsString"+e]=lookupUnits(1,c.data.ainPayloads[e].sensorUnits0);else 120<=b&&129>=b&&(d="Modbus Standard Variable Length");c.data.fport=b;c.data.voboType=a;c.data.payloadType=
+d;return c}function parseStandardPayload(a){var b={};b.DIN1=a[0]&1;b.DIN2=a[0]>>1&1;b.DIN3=a[0]>>2&1;b.WKUP=a[0]>>3&1;b.ADC1=(a[0]&240)>>4|a[1]<<4;b.ADC2=(a[3]&15)<<8|a[2];b.ADC3=(a[3]&240)>>4|a[4]<<4;b.Battery=4*((a[6]&15)<<8|a[5]);b.Temperature=0==(a[7]>>7&1)?.125*((a[6]&240)>>4|a[7]<<4):-.125*(4096-((a[6]&240)>>4|a[7]<<4));b.Modbus0=a[9]<<8|a[8];return b}
 function parseModbusStandardPayload(a,b){b=5*(b-1)-4;var c={};c["Modbus"+b++]=a[1]<<8|a[0];c["Modbus"+b++]=a[3]<<8|a[2];c["Modbus"+b++]=a[5]<<8|a[4];c["Modbus"+b++]=a[7]<<8|a[6];c["Modbus"+b]=a[9]<<8|a[8];return c}
 function parseHeartbeat1p0Payload(a){var b={};b.batteryLevelMV=4*((a[1]&15)<<8|a[0]);b.fwVersionMajor=a[2]&15|(a[1]&240)>>4;b.fwVersionMinor=a[3]&15|(a[2]&240)>>4;b.fwVersionPatch=a[4]&15|(a[3]&240)>>4;b.fwVersionCustom=(a[4]&240)>>4;b.recSignalLevels=-1*a[5];b.analogVoltageConfig=a[6]&31;b.analogPowerTimeConfig=parseFloat((((a[7]&31)<<3|(a[6]&224)>>5)/10).toFixed(1));b.failedTransmissionBeforeRejoinConfig=(a[8]&1)<<3|(a[7]&224)>>5;b.cycleThroughFSB=(a[8]&2)>>1;b.ackEnable=(a[8]&4)>>2;b.ackFreq=(a[8]&
 120)>>3;b.ackReq=(a[9]&7)<<1|(a[8]&128)>>7;b.batteryLevelThreshold=4*((a[10]&127)<<5|(a[9]&248)>>3);return b}
@@ -77,8 +98,8 @@ function parseHeartbeat2p0Payload(a){var b={};b.batteryLevel=(a[1]&15)<<8|a[0];b
 function bytesToFloat32(a){var b=new ArrayBuffer(4),c=new Uint8Array(b);c[0]=a[0];c[1]=a[1];c[2]=a[2];c[3]=a[3];return(new DataView(b)).getFloat32(0,!1)}function parseOneAnalogSensorPayload(a){var b={};b.sensorNum0=a[0];b.sensorUnits0=a[1];b.sensorData0=bytesToFloat32(a.slice(2,6));return b}
 function parseTwoAnalogSensorsPayload(a){var b={};b.sensorNum0=(a[0]&240)>>4;b.sensorUnits0=a[1];b.sensorData0=bytesToFloat32(a.slice(2,6));b.sensorNum1=a[0]&15;b.sensorUnits1=a[6];b.sensorData1=bytesToFloat32(a.slice(7,11));return b}function parseDigitalSensorsPayload(a){var b={};b.sensorValid0=a[1]<<8|a[0];b.sensorData0=a[3]<<8|a[2];return b}
 function parseEventLogPayload(a){var b={};b.eventTimestamp=a[0]+a[1]*Math.pow(2,8)+a[2]*Math.pow(2,16)+a[3]*Math.pow(2,24);b.eventCode=a[4]+a[5]*Math.pow(2,8);b.metadata=Array.prototype.slice.call(a.slice(6,11),0);return b}
-function parseVoboLibGeneralConfigurationPayload(a){var b={};b.subgroupID=a[0]&15;b.sequenceNumber=(a[0]&240)>>4;0==b.sequenceNumber&&(b.transRejoin=a[1]&15,b.ackFrequency=(a[1]&240)>>4,b.lowBattery=parseFloat(((a[2]&15)/10+2.5).toFixed(1)),b.reserved1=(a[2]&16)>>4,b.heartbeatAckEnable=!!((a[2]&32)>>5),b.operationMode=(a[2]&64)>>6,b.cycleSubBands=!!((a[2]&128)>>7),b.ackRetries=a[3]&7,b.reservedLL=(a[3]&56)>>3,b.ackEnable=!!((a[3]&64)>>6),b.heartbeatEnable=!!((a[3]&128)>>7),b.cycleTime=(a[6]&3)<<16|
-a[5]<<8|a[4],b.backOffReset=(a[6]&252)>>2,b.reservedRD=a[7]&63,b.reserved2=(a[7]&192)>>6,b.resendAttempts=a[8]&15,b.freqSubBand=(a[8]&240)>>4);if(1==b.sequenceNumber){b.timeSyncInterval=a[1];b.joinEUI="";for(let c=9;2<=c;c--)b.joinEUI+=a[c].toString(16).toUpperCase().padStart(2,0),2!=c&&(b.joinEUI+="-");b.joinNonceResetEnable=!!(a[10]&1);b.timeSyncWakeupEnable=!!((a[10]&2)>>1);b.reserved1=(a[10]&252)>>2}return b}
+function parseVoboLibGeneralConfigurationPayload(a,b){var c={};c.subgroupID=a[0]&15;c.sequenceNumber=(a[0]&240)>>4;0==c.sequenceNumber&&(c.transRejoin=a[1]&15,c.ackFrequency=(a[1]&240)>>4,70==b||71==b?c.lowBattery=parseFloat(((a[2]&15)/10+2.5).toFixed(1)):72==b&&(c.lowVoltThreshold=parseFloat(((a[2]&15)/10+2.5).toFixed(1))),c.reserved1=(a[2]&16)>>4,c.heartbeatAckEnable=!!((a[2]&32)>>5),c.operationMode=(a[2]&64)>>6,c.cycleSubBands=!!((a[2]&128)>>7),c.ackRetries=a[3]&7,c.reservedLL=(a[3]&56)>>3,c.ackEnable=
+!!((a[3]&64)>>6),c.heartbeatEnable=!!((a[3]&128)>>7),c.cycleTime=(a[6]&3)<<16|a[5]<<8|a[4],c.backOffReset=(a[6]&252)>>2,c.reservedRD=a[7]&63,c.reserved2=(a[7]&192)>>6,c.resendAttempts=a[8]&15,c.freqSubBand=(a[8]&240)>>4);if(1==c.sequenceNumber){c.timeSyncInterval=a[1];c.joinEUI="";for(b=9;2<=b;b--)c.joinEUI+=a[b].toString(16).toUpperCase().padStart(2,0),2!=b&&(c.joinEUI+="-");c.joinNonceResetEnable=!!(a[10]&1);c.timeSyncWakeupEnable=!!((a[10]&2)>>1);c.reserved1=(a[10]&252)>>2}return c}
 function parseVoboLibVoboSyncConfigurationPayload(a){var b={};b.subgroupID=a[0]&15;b.sequenceNumber=(a[0]&240)>>4;0==b.sequenceNumber&&(b.vbsNodeNumber=a[2]<<8|a[1],b.vbsTimeReference=a.slice(3,7).readUInt32LE(),b.reservedVCPDS=a[7]&15,b.reservedVMPDS=(a[7]&240)>>4,b.reservedVUDS=a[8]&15,b.reserved1=(a[8]&48)>>4,b.reservedVSAE=!!((a[8]&64)>>6),b.vbsEnable=!!((a[8]&128)>>7),b.reserved3=a[9]&63,b.reserved2=(a[9]&192)>>6);1==b.sequenceNumber&&(b.vbsMeasurementDelaySec=a[1]&127,b.reserved1=(a[1]&128)>>
 7,b.vbsUplinkDelaySec=a[2]&127,b.reserved2=(a[2]&128)>>7);return b}
 function parseVoboXXGeneralConfigurationPayload(a){var b={};b.subgroupID=a[0]&15;b.sequenceNumber=(a[0]&240)>>4;b.analogVoltage=parseFloat((a[1]/10).toFixed(1));b.powerTime=parseFloat((a[2]/10).toFixed(1));b.mbEnable=!!(a[3]&1);b.engUnitsEnable=!!(a[3]>>1&1);b.din1TransmitEnable=!!(a[3]>>2&1);b.din2TransmitEnable=!!(a[3]>>3&1);b.din3TransmitEnable=!!(a[3]>>4&1);b.wkupTransmitEnable=!!(a[3]>>5&1);b.ain1TransmitEnable=!!(a[3]>>6&1);b.ain2TransmitEnable=!!(a[3]>>7&1);b.ain3TransmitEnable=!!(a[4]&1);
@@ -110,8 +131,14 @@ function parseVoboTCCalibrationConfigurationPayload(a){var b={};b.subgroupID=a[0
 b.reserved2=(a[4]&128)>>7,b.gain6=parseFloat((((a[6]&7)<<8|a[5])/1E3).toFixed(3)),b.reserved3=(a[6]&248)>>3,b.offset6=parseFloat((((a[8]&127)<<8|a[7])/1E3-10).toFixed(3)),b.reserved4=(a[8]&128)>>7);3==b.sequenceNumber&&(b.gain7=parseFloat((((a[2]&7)<<8|a[1])/1E3).toFixed(3)),b.reserved1=(a[2]&248)>>3,b.offset7=parseFloat((((a[4]&127)<<8|a[3])/1E3-10).toFixed(3)),b.reserved2=(a[4]&128)>>7,b.gain8=parseFloat((((a[6]&7)<<8|a[5])/1E3).toFixed(3)),b.reserved3=(a[6]&248)>>3,b.offset8=parseFloat((((a[8]&
 127)<<8|a[7])/1E3-10).toFixed(3)),b.reserved4=(a[8]&128)>>7);4==b.sequenceNumber&&(b.gain9=parseFloat((((a[2]&7)<<8|a[1])/1E3).toFixed(3)),b.reserved1=(a[2]&248)>>3,b.offset9=parseFloat((((a[4]&127)<<8|a[3])/1E3-10).toFixed(3)),b.reserved2=(a[4]&128)>>7,b.gain10=parseFloat((((a[6]&7)<<8|a[5])/1E3).toFixed(3)),b.reserved3=(a[6]&248)>>3,b.offset10=parseFloat((((a[8]&127)<<8|a[7])/1E3-10).toFixed(3)),b.reserved4=(a[8]&128)>>7);5==b.sequenceNumber&&(b.gain11=parseFloat((((a[2]&7)<<8|a[1])/1E3).toFixed(3)),
 b.reserved1=(a[2]&248)>>3,b.offset11=parseFloat((((a[4]&127)<<8|a[3])/1E3-10).toFixed(3)),b.reserved2=(a[4]&128)>>7,b.gain12=parseFloat((((a[6]&7)<<8|a[5])/1E3).toFixed(3)),b.reserved3=(a[6]&248)>>3,b.offset12=parseFloat((((a[8]&127)<<8|a[7])/1E3-10).toFixed(3)),b.reserved4=(a[8]&128)>>7);return b}
-function parseConfigurationPayload(a,b){var c={},d=a[0]&15;0==d?c=parseVoboLibGeneralConfigurationPayload(a):1==d?c=parseVoboLibVoboSyncConfigurationPayload(a):70==b&&4==d?c=parseVoboXXGeneralConfigurationPayload(a):70==b&&5==d?c=parseVoboXXModbusGeneralConfigurationPayload(a):70!=b||6!=d&&7!=d?70!=b||8!=d&&9!=d&&10!=d?70==b&&11==d?c=parseVoboXXModbusPayloadsSlotsConfigurationPayload(a):70==b&&12==d?c=parseVoboXXEngineeringUnitsConfigurationPayload(a):71==b&&4==d?c=parseVoboTCGeneralConfigurationPayload(a):
-71==b&&5==d&&(c=parseVoboTCCalibrationConfigurationPayload(a)):c=parseVoboXXModbusGroupsConfigurationPayload(a):c=parseVoboXXModbusGroupsEnableConfigurationPayload(a);return c}
+function parseVoboXPGeneralConfigurationPayload(a){var b={};b.subgroupID=a[0]&15;b.sequenceNumber=(a[0]&240)>>4;0==b.sequenceNumber&&(b.analogVoltage=parseFloat((a[1]/10).toFixed(1)),b.powerTime=parseFloat((a[2]/10).toFixed(1)),b.mbEnable=!!(a[3]&1),b.reserved1=a[3]>>1&127,b.reserved2=a[4]&7,b.mbTransmitEnable=!!(a[4]>>3&1),b.ainPayloadType=a[4]>>4&1,b.reservedMAWE=!!(a[4]>>5&1),b.reservedMADE=!!(a[4]>>6&1),b.reservedMAME=!!(a[4]>>7&1),b.reservedDTC=a[6]<<8|a[5]);1==b.sequenceNumber&&(b.stateRLY1=
+a[1]&1,b.stateRLY2=a[1]>>1&1,b.stateRLY3=a[1]>>2&1,b.stateRLY4=a[1]>>3&1,b.reserved1=a[1]>>4&15,b.lorawanClass=a[2]&1,b.contMeasEnable=!!(a[2]>>1&1),b.reservedARDE=!!(a[2]>>2&1),b.pFailWarnEnable=!!(a[2]>>3&1),b.pcntDin1Enable=!!(a[2]>>4&1),b.pcntDin2Enable=!!(a[2]>>5&1),b.reserved2=a[2]>>6&3,b.pcntDin1Type=a[3]&3,b.pcntDin2Type=a[3]>>2&3,b.reserved3=a[3]>>4&15,b.pcntPeriod=a[4]&63,b.reserved4=a[4]>>6&3,b.contMeasCycleTime=a[5]&63,b.reserved5=a[5]>>6&3,b.pFailThreshold=parseFloat((a[6]/10).toFixed(1)),
+b.serialPHY=a[7]&1,b.reserved6=a[7]>>1&7,b.serialProtoRS485=a[7]>>4&1,b.reserved7=a[7]>>5&1,b.serialProtoRS232=a[7]>>6&1,b.reserved8=a[7]>>7&1);return b}
+function parseVoboXPTransmitEncodingConfigurationPayload(a){var b={};b.subgroupID=a[0]&15;b.sequenceNumber=(a[0]&240)>>4;b.txAin1=a[1]&15;b.txAin2=a[1]>>4&15;b.txAin3=a[2]&15;b.txDin1=a[2]>>4&15;b.txDin2=a[3]&15;b.txPcntDin1=a[3]>>4&15;b.txPcntDin2=a[4]&15;b.txWKUP=a[4]>>4&15;b.txTemp=a[5]&15;b.txVoltRLY1=a[5]>>4&15;b.txVoltRLY2=a[6]&15;b.txVoltRLY3=a[6]>>4&15;b.txVoltRLY4=a[7]&15;b.txVoltVIN=a[7]>>4&15;b.txVolt3V3=a[8]&15;b.txVoltVPP=a[8]>>4&15;b.txContMeasPeriod=a[9]&15;b.txContMeasCnt=a[9]>>4&
+1;b.reserved1=a[9]>>5&7;return b}function parseVoboXPRelayPulseConfigurationPayload(a){var b={};b.subgroupID=a[0]&15;b.sequenceNumber=(a[0]&240)>>4;0==b.sequenceNumber?(b.pulseDelayRLY1=a[2]<<8|a[1],b.pulsePeriodRLY1=a[4]<<8|a[3],b.pulseDelayRLY2=a[6]<<8|a[5],b.pulsePeriodRLY2=a[8]<<8|a[7]):1==b.sequenceNumber&&(b.pulseDelayRLY3=a[2]<<8|a[1],b.pulsePeriodRLY3=a[4]<<8|a[3],b.pulseDelayRLY4=a[6]<<8|a[5],b.pulsePeriodRLY4=a[8]<<8|a[7]);return b}
+function parseConfigurationPayload(a,b){var c={},d=a[0]&15;0==d?c=parseVoboLibGeneralConfigurationPayload(a,b):1==d?c=parseVoboLibVoboSyncConfigurationPayload(a):70==b&&4==d?c=parseVoboXXGeneralConfigurationPayload(a):70==b&&5==d?c=parseVoboXXModbusGeneralConfigurationPayload(a):70!=b||6!=d&&7!=d?70!=b||8!=d&&9!=d&&10!=d?70==b&&11==d?c=parseVoboXXModbusPayloadsSlotsConfigurationPayload(a):70==b&&12==d?c=parseVoboXXEngineeringUnitsConfigurationPayload(a):71==b&&4==d?c=parseVoboTCGeneralConfigurationPayload(a):
+71==b&&5==d?c=parseVoboTCCalibrationConfigurationPayload(a):72==b&&4==d?c=parseVoboXPGeneralConfigurationPayload(a):72==b&&5==d?c=parseVoboXXModbusGeneralConfigurationPayload(a):72!=b||6!=d&&7!=d?72!=b||8!=d&&9!=d&&10!=d?72==b&&11==d?c=parseVoboXXModbusPayloadsSlotsConfigurationPayload(a):72==b&&12==d?c=parseVoboXXEngineeringUnitsConfigurationPayload(a):72==b&&13==d?c=parseVoboXPTransmitEncodingConfigurationPayload(a):72==b&&14==d&&(c=parseVoboXPRelayPulseConfigurationPayload(a)):c=parseVoboXXModbusGroupsConfigurationPayload(a):
+c=parseVoboXXModbusGroupsEnableConfigurationPayload(a):c=parseVoboXXModbusGroupsConfigurationPayload(a):c=parseVoboXXModbusGroupsEnableConfigurationPayload(a);return c}
 function parseModbusGenericPayload(a,b){b={};for(var c=a.length,d=0;d<c-1;){var e=a[d]&63;if(0<e){var f=a[d]>>6&3;d++;if(0==f){var g=a[d+1]<<8|a[d];b["group"+e+"register1"]=g;d+=2}else if(1==f)b["group"+e+"register1"]=a[d+1]<<8|a[d],b["group"+e+"register2"]=a[d+3]<<8|a[d+2],d+=4;else if(2==f){f=[];var h=a[d]&127;d++;for(var k=0;k<h;k++)g=a[d+1]<<8|a[d],b["group"+e+"register"+(k+1)]=g,f.push(g),d+=2}else if(3==f){f=[];h=a[d]&127;d++;k=a[d]&127;d++;h-=k;g=Math.floor((c-d)/2);h>g&&(h=g);for(let l=0;l<
 h;l++)g=a[d+1]<<8|a[d],b["group"+e+"register"+(k+l+1)]=g,f.push(g),d+=2}}else break}return b}function parseAnalogInputVariableLengthPayload(a,b){b={};for(var c=[],d=a.length,e=0;e<d;){var f=a.slice(e,e+6);f=parseOneAnalogSensorPayload(f);c.push(f);e+=6}b.ainPayloads=c;b.numOfAinPayloads=c.length;return b}
 function parseModbusStandardVariableLengthPayload(a,b){b={};for(var c={},d=a.length,e=a[d-1],f=0;f<d-1;)c["Modbus"+(e+f/2)]=a[f+1]<<8|a[f],f+=2;b.modbusSlots=c;b.firstSlotNum=e;b.numModbusSlots=(d-1)/2;return b}
@@ -119,8 +146,8 @@ function lookupAnalogSensorName(a,b){var c=[{"Analog Sensor Number":"0","Analog 
 "Analog Sensor Name":"TC2"},{"Analog Sensor Number":"3","Analog Sensor Name":"TC3"},{"Analog Sensor Number":"4","Analog Sensor Name":"TC4"},{"Analog Sensor Number":"5","Analog Sensor Name":"TC5"},{"Analog Sensor Number":"6","Analog Sensor Name":"TC6"},{"Analog Sensor Number":"7","Analog Sensor Name":"TC7"},{"Analog Sensor Number":"8","Analog Sensor Name":"TC8"},{"Analog Sensor Number":"9","Analog Sensor Name":"TC9"},{"Analog Sensor Number":"10","Analog Sensor Name":"TC10"},{"Analog Sensor Number":"11",
 "Analog Sensor Name":"TC11"},{"Analog Sensor Number":"12","Analog Sensor Name":"TC12"},{"Analog Sensor Number":"13","Analog Sensor Name":"Cold Joint Temperature"}],e=[{"Analog Sensor Number":"0","Analog Sensor Name":"3.3V Supply Voltage"},{"Analog Sensor Number":"1","Analog Sensor Name":"AIN1"},{"Analog Sensor Number":"2","Analog Sensor Name":"AIN2"},{"Analog Sensor Number":"3","Analog Sensor Name":"AIN3"},{"Analog Sensor Number":"4","Analog Sensor Name":"DIN1"},{"Analog Sensor Number":"5","Analog Sensor Name":"DIN1 Pulse Count"},
 {"Analog Sensor Number":"6","Analog Sensor Name":"DIN2"},{"Analog Sensor Number":"7","Analog Sensor Name":"DIN2 Pulse Count"},{"Analog Sensor Number":"8","Analog Sensor Name":"RLY1 Voltage"},{"Analog Sensor Number":"9","Analog Sensor Name":"RLY2 Voltage"},{"Analog Sensor Number":"10","Analog Sensor Name":"RLY3 Voltage"},{"Analog Sensor Number":"11","Analog Sensor Name":"RLY4 Voltage"},{"Analog Sensor Number":"12","Analog Sensor Name":"WKUP"},{"Analog Sensor Number":"13","Analog Sensor Name":"VPP Voltage"},
-{"Analog Sensor Number":"14","Analog Sensor Name":"VIN Voltage"},{"Analog Sensor Number":"15","Analog Sensor Name":"ADC Temperature"},{"Analog Sensor Number":"16","Analog Sensor Name":"Cont Meas Period"},{"Analog Sensor Number":"17","Analog Sensor Name":"Cont Meas Count"}];var f=[],g="";if("VoBoXX"==a)f=c;else if("VoBoTC"==a)f=d;else if("VoBoXP"==a)f=e,c=(b&192)>>6,1==c?g="(Max)":2==c?g="(Min)":3==c&&(g="(Avg)"),b&=63;else throw errorMsg=a+' -- Invalid VoBo Type. Use "VoBoXX", "VoBoTC" or "VoBoXP"',
-Error(errorMsg);f=f.find(h=>h["Analog Sensor Number"]==b.toString());if("undefined"==typeof f)return"AnalogSensor"+b.toString();f=f["Analog Sensor Name"];"VoBoXP"==a&&(f=f+" "+g);return f}
+{"Analog Sensor Number":"14","Analog Sensor Name":"VIN Voltage"},{"Analog Sensor Number":"15","Analog Sensor Name":"ADC Temperature"},{"Analog Sensor Number":"16","Analog Sensor Name":"Cont Meas Period"},{"Analog Sensor Number":"17","Analog Sensor Name":"Cont Meas Count"}];var f=[],g="";if("VoBoXX"==a)f=c;else if("VoBoTC"==a)f=d;else if("VoBoXP"==a)f=e,c=(b&192)>>6,1==c?g=" (Max)":2==c?g=" (Min)":3==c&&(g=" (Avg)"),b&=63;else throw errorMsg=a+' -- Invalid VoBo Type. Use "VoBoXX", "VoBoTC" or "VoBoXP"',
+Error(errorMsg);f=f.find(h=>h["Analog Sensor Number"]==b.toString());if("undefined"==typeof f)return"AnalogSensor"+b.toString();f=f["Analog Sensor Name"];"VoBoXP"==a&&(f+=g);return f}
 function lookupDigitalSensorName(a,b){const c=[{"Digital Sensor Number":"0","Digital Sensor Name":"WKUP"},{"Digital Sensor Number":"1","Digital Sensor Name":"DIN1"},{"Digital Sensor Number":"2","Digital Sensor Name":"DIN2"},{"Digital Sensor Number":"3","Digital Sensor Name":"DIN3"}],d=[{"Digital Sensor Number":"0","Digital Sensor Name":"WKUP"}],e=[{"Digital Sensor Number":"0","Digital Sensor Name":"WKUP"},{"Digital Sensor Number":"1","Digital Sensor Name":"DIN1"},{"Digital Sensor Number":"2","Digital Sensor Name":"DIN2"}];
 var f=[];if("VoBoXX"==a)f=c;else if("VoBoTC"==a)f=d;else if("VoBoXP"==a)f=e;else throw errorMsg=a+' -- Invalid VoBo Type. Use "VoBoXX", "VoBoTC" or "VoBoXP"',Error(errorMsg);a=f.find(g=>g["Digital Sensor Number"]==b.toString());return"undefined"==typeof a?"DigitalSensor"+b.toString():a["Digital Sensor Name"]}
 function lookupUnits(a,b){var c="";c=[{"Units Code":"1",Description:"inches of water at 20 degC (68 degF)","Abbreviated Units":"inH2O (20 degC or 68 degF)"},{"Units Code":"2",Description:"inches of mercury at 0 degC (32 degF)","Abbreviated Units":"inHg (20 degC or 68 degF)"},{"Units Code":"3",Description:"feet of water at 20 degC (68 degF)","Abbreviated Units":"ftH2O (20 degC or 68 degF)"},{"Units Code":"4",Description:"millimeters of water at 20 degC (68 degF)","Abbreviated Units":"mmH2O (20 degC or 68 degF)"},
@@ -161,15 +188,15 @@ Description:"gallons per day","Abbreviated Units":"usg/d"},{"Units Code":"236",D
 // exports had to be commented out.
 //===========================================================
 
-const payload_vb = payload.find((x) => x.variable === "payload");
-const fPort_vb = payload.find((x) => x.variable === "port" || x.variable === "fPort")?.value;
+const payload_vb = payload.find((x) => x.variable === "payload_raw" || x.variable === "payload" || x.variable === "data");
+const fPort_vb = payload.find((x) => x.variable === "port" || x.variable === "fPort" || x.variable === "fport" || x.variable === "FPort")?.value;
 
 if (payload_vb) {
     try {
         const buffer = Buffer.from(payload_vb.value, "hex")
         const decoded = toTagoFormat(buffer, fPort_vb);
-        payload = decoded;
-    } catch (error: any) {
+        payload = payload.concat(decoded);
+    } catch (error) {
         console.error(error);
         payload = [{ variable: "parse_error", value: error.message }];
     }

--- a/decoders/connector/volley-boast/vobo-hl-1/v1.0.0/payload.js
+++ b/decoders/connector/volley-boast/vobo-hl-1/v1.0.0/payload.js
@@ -12,7 +12,7 @@ function customDecoder(bytes, fport) {
             {
             variable: decoded.data.analogSensorString0,
             value: decoded.data.sensorData0,
-            units: decoded.data.engUnitsString0
+            unit: decoded.data.engUnitsString0
             }
         ];
         tagoDecoded.push(
@@ -26,12 +26,12 @@ function customDecoder(bytes, fport) {
             {
                 variable: decoded.data.analogSensorString0,
                 value: decoded.data.sensorData0,
-                units: decoded.data.engUnitsString0
+                unit: decoded.data.engUnitsString0
             },
             {
                 variable: decoded.data.analogSensorString1,
                 value: decoded.data.sensorData1,
-                units: decoded.data.engUnitsString1
+                unit: decoded.data.engUnitsString1
             }
         ];
         tagoDecoded.push(
@@ -55,7 +55,7 @@ function customDecoder(bytes, fport) {
         var tagoDecoded = decoded.data.ainPayloads.map((payloadObj, index) => ({
             variable: decoded.data[`analogSensorString${index}`],
             value: payloadObj.sensorData0,
-            units: decoded.data[`engUnitsString${index}`]
+            unit: decoded.data[`engUnitsString${index}`]
         }));
         tagoDecoded.push(
             { variable: "fport", value: decoded.data.fport },

--- a/decoders/connector/volley-boast/vobo-hl-1/v1.0.0/payload.test.ts
+++ b/decoders/connector/volley-boast/vobo-hl-1/v1.0.0/payload.test.ts
@@ -34,22 +34,38 @@ describe(`fPort: ${testPayloads.data[0].fport} - ${testPayloads.data[0].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const din1 = payload.find((item) => item.variable === 'DIN1');
+    const din2 = payload.find((item) => item.variable === 'DIN2');
+    const din3 = payload.find((item) => item.variable === 'DIN3');
+    const wkup = payload.find((item) => item.variable === 'WKUP');
+    const adc1 = payload.find((item) => item.variable === 'ADC1');
+    const adc2 = payload.find((item) => item.variable === 'ADC2');
+    const adc3 = payload.find((item) => item.variable === 'ADC3');
+    const battery = payload.find((item) => item.variable === 'Battery');
+    const temperature = payload.find((item) => item.variable === 'Temperature');
+    const modbus0 = payload.find((item) => item.variable === 'Modbus0');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+    
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'DIN1', value: 1 },
-            { variable: 'DIN2', value: 1 },
-            { variable: 'DIN3', value: 1 },
-            { variable: 'WKUP', value: 0 },
-            { variable: 'ADC1', value: 994 },
-            { variable: 'ADC2', value: 1009 },
-            { variable: 'ADC3', value: 1603 },
-            { variable: 'Battery', value: 3528 },
-            { variable: 'Temperature', value: 25.75 },
-            { variable: 'Modbus0', value: 0 },
-            { variable: 'fport', value: 1 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Standard' }
-        ]);
+        expect(din1.value).toBe(1);
+        expect(din2.value).toBe(1);
+        expect(din3.value).toBe(1);
+        expect(wkup.value).toBe(0);
+        expect(adc1.value).toBe(994);
+        expect(adc2.value).toBe(1009);
+        expect(adc3.value).toBe(1603);
+        expect(battery.value).toBe(3528);
+        expect(temperature.value).toBe(25.75);
+        expect(modbus0.value).toBe(0);
+        expect(fport.value).toBe(1);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Standard');
     });
 });
 
@@ -61,17 +77,28 @@ describe(`fPort: ${testPayloads.data[1].fport} - ${testPayloads.data[1].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const modbus1 = payload.find((item) => item.variable === 'Modbus1');
+    const modbus2 = payload.find((item) => item.variable === 'Modbus2');
+    const modbus3 = payload.find((item) => item.variable === 'Modbus3');
+    const modbus4 = payload.find((item) => item.variable === 'Modbus4');
+    const modbus5 = payload.find((item) => item.variable === 'Modbus5');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'Modbus1', value: 8705 },
-            { variable: 'Modbus2', value: 8706 },
-            { variable: 'Modbus3', value: 8707 },
-            { variable: 'Modbus4', value: 8708 },
-            { variable: 'Modbus5', value: 8709 },
-            { variable: 'fport', value: 2 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Modbus Standard' }
-        ]);
+        expect(modbus1.value).toBe(8705);
+        expect(modbus2.value).toBe(8706);
+        expect(modbus3.value).toBe(8707);
+        expect(modbus4.value).toBe(8708);
+        expect(modbus5.value).toBe(8709);
+        expect(fport.value).toBe(2);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Modbus Standard');
     });
 });
 
@@ -83,17 +110,28 @@ describe(`fPort: ${testPayloads.data[2].fport} - ${testPayloads.data[2].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const modbus6 = payload.find((item) => item.variable === 'Modbus6');
+    const modbus7 = payload.find((item) => item.variable === 'Modbus7');
+    const modbus8 = payload.find((item) => item.variable === 'Modbus8');
+    const modbus9 = payload.find((item) => item.variable === 'Modbus9');
+    const modbus10 = payload.find((item) => item.variable === 'Modbus10');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'Modbus6', value: 8705 },
-            { variable: 'Modbus7', value: 8706 },
-            { variable: 'Modbus8', value: 8707 },
-            { variable: 'Modbus9', value: 8708 },
-            { variable: 'Modbus10', value: 8709 },
-            { variable: 'fport', value: 3 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Modbus Standard' }
-        ]);
+        expect(modbus6.value).toBe(8705);
+        expect(modbus7.value).toBe(8706);
+        expect(modbus8.value).toBe(8707);
+        expect(modbus9.value).toBe(8708);
+        expect(modbus10.value).toBe(8709);
+        expect(fport.value).toBe(3);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Modbus Standard');
     });
 });
 
@@ -105,17 +143,28 @@ describe(`fPort: ${testPayloads.data[3].fport} - ${testPayloads.data[3].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const modbus11 = payload.find((item) => item.variable === 'Modbus11');
+    const modbus12 = payload.find((item) => item.variable === 'Modbus12');
+    const modbus13 = payload.find((item) => item.variable === 'Modbus13');
+    const modbus14 = payload.find((item) => item.variable === 'Modbus14');
+    const modbus15 = payload.find((item) => item.variable === 'Modbus15');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'Modbus11', value: 8705 },
-            { variable: 'Modbus12', value: 8706 },
-            { variable: 'Modbus13', value: 8707 },
-            { variable: 'Modbus14', value: 8708 },
-            { variable: 'Modbus15', value: 8709 },
-            { variable: 'fport', value: 4 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Modbus Standard' }
-        ]);
+        expect(modbus11.value).toBe(8705);
+        expect(modbus12.value).toBe(8706);
+        expect(modbus13.value).toBe(8707);
+        expect(modbus14.value).toBe(8708);
+        expect(modbus15.value).toBe(8709);
+        expect(fport.value).toBe(4);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Modbus Standard');
     });
 });
 
@@ -127,17 +176,28 @@ describe(`fPort: ${testPayloads.data[4].fport} - ${testPayloads.data[4].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const modbus16 = payload.find((item) => item.variable === 'Modbus16');
+    const modbus17 = payload.find((item) => item.variable === 'Modbus17');
+    const modbus18 = payload.find((item) => item.variable === 'Modbus18');
+    const modbus19 = payload.find((item) => item.variable === 'Modbus19');
+    const modbus20 = payload.find((item) => item.variable === 'Modbus20');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'Modbus16', value: 8705 },
-            { variable: 'Modbus17', value: 8706 },
-            { variable: 'Modbus18', value: 8707 },
-            { variable: 'Modbus19', value: 8708 },
-            { variable: 'Modbus20', value: 8709 },
-            { variable: 'fport', value: 5 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Modbus Standard' }
-        ]);
+        expect(modbus16.value).toBe(8705);
+        expect(modbus17.value).toBe(8706);
+        expect(modbus18.value).toBe(8707);
+        expect(modbus19.value).toBe(8708);
+        expect(modbus20.value).toBe(8709);
+        expect(fport.value).toBe(5);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Modbus Standard');
     });
 });
 
@@ -149,17 +209,28 @@ describe(`fPort: ${testPayloads.data[5].fport} - ${testPayloads.data[5].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const modbus21 = payload.find((item) => item.variable === 'Modbus21');
+    const modbus22 = payload.find((item) => item.variable === 'Modbus22');
+    const modbus23 = payload.find((item) => item.variable === 'Modbus23');
+    const modbus24 = payload.find((item) => item.variable === 'Modbus24');
+    const modbus25 = payload.find((item) => item.variable === 'Modbus25');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'Modbus21', value: 8705 },
-            { variable: 'Modbus22', value: 8706 },
-            { variable: 'Modbus23', value: 8707 },
-            { variable: 'Modbus24', value: 8708 },
-            { variable: 'Modbus25', value: 8709 },
-            { variable: 'fport', value: 6 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Modbus Standard' }
-        ]);
+        expect(modbus21.value).toBe(8705);
+        expect(modbus22.value).toBe(8706);
+        expect(modbus23.value).toBe(8707);
+        expect(modbus24.value).toBe(8708);
+        expect(modbus25.value).toBe(8709);
+        expect(fport.value).toBe(6);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Modbus Standard');
     });
 });
 
@@ -171,17 +242,28 @@ describe(`fPort: ${testPayloads.data[6].fport} - ${testPayloads.data[6].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const modbus26 = payload.find((item) => item.variable === 'Modbus26');
+    const modbus27 = payload.find((item) => item.variable === 'Modbus27');
+    const modbus28 = payload.find((item) => item.variable === 'Modbus28');
+    const modbus29 = payload.find((item) => item.variable === 'Modbus29');
+    const modbus30 = payload.find((item) => item.variable === 'Modbus30');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'Modbus26', value: 8705 },
-            { variable: 'Modbus27', value: 8706 },
-            { variable: 'Modbus28', value: 8707 },
-            { variable: 'Modbus29', value: 8708 },
-            { variable: 'Modbus30', value: 8709 },
-            { variable: 'fport', value: 7 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Modbus Standard' }
-        ]);
+        expect(modbus26.value).toBe(8705);
+        expect(modbus27.value).toBe(8706);
+        expect(modbus28.value).toBe(8707);
+        expect(modbus29.value).toBe(8708);
+        expect(modbus30.value).toBe(8709);
+        expect(fport.value).toBe(7);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Modbus Standard');
     });
 });
 
@@ -193,17 +275,28 @@ describe(`fPort: ${testPayloads.data[7].fport} - ${testPayloads.data[7].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const modbus31 = payload.find((item) => item.variable === 'Modbus31');
+    const modbus32 = payload.find((item) => item.variable === 'Modbus32');
+    const modbus33 = payload.find((item) => item.variable === 'Modbus33');
+    const modbus34 = payload.find((item) => item.variable === 'Modbus34');
+    const modbus35 = payload.find((item) => item.variable === 'Modbus35');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'Modbus31', value: 8705 },
-            { variable: 'Modbus32', value: 8706 },
-            { variable: 'Modbus33', value: 8707 },
-            { variable: 'Modbus34', value: 8708 },
-            { variable: 'Modbus35', value: 8709 },
-            { variable: 'fport', value: 8 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Modbus Standard' }
-        ]);
+        expect(modbus31.value).toBe(8705);
+        expect(modbus32.value).toBe(8706);
+        expect(modbus33.value).toBe(8707);
+        expect(modbus34.value).toBe(8708);
+        expect(modbus35.value).toBe(8709);
+        expect(fport.value).toBe(8);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Modbus Standard');
     });
 });
 
@@ -215,17 +308,28 @@ describe(`fPort: ${testPayloads.data[8].fport} - ${testPayloads.data[8].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const modbus36 = payload.find((item) => item.variable === 'Modbus36');
+    const modbus37 = payload.find((item) => item.variable === 'Modbus37');
+    const modbus38 = payload.find((item) => item.variable === 'Modbus38');
+    const modbus39 = payload.find((item) => item.variable === 'Modbus39');
+    const modbus40 = payload.find((item) => item.variable === 'Modbus40');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'Modbus36', value: 8705 },
-            { variable: 'Modbus37', value: 8706 },
-            { variable: 'Modbus38', value: 8707 },
-            { variable: 'Modbus39', value: 8708 },
-            { variable: 'Modbus40', value: 8709 },
-            { variable: 'fport', value: 9 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Modbus Standard' }
-        ]);
+        expect(modbus36.value).toBe(8705);
+        expect(modbus37.value).toBe(8706);
+        expect(modbus38.value).toBe(8707);
+        expect(modbus39.value).toBe(8708);
+        expect(modbus40.value).toBe(8709);
+        expect(fport.value).toBe(9);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Modbus Standard');
     });
 });
 
@@ -237,26 +341,45 @@ describe(`fPort: ${testPayloads.data[9].fport} - ${testPayloads.data[9].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const batteryLevel = payload.find((item) => item.variable === 'batteryLevel');
+    const fatalErrorsTotal = payload.find((item) => item.variable === 'fatalErrorsTotal');
+    const rssiAvg = payload.find((item) => item.variable === 'rssiAvg');
+    const failedJoinAttemptsTotal = payload.find((item) => item.variable === 'failedJoinAttemptsTotal');
+    const configUpdateOccurred = payload.find((item) => item.variable === 'configUpdateOccurred');
+    const firmwareRevision = payload.find((item) => item.variable === 'firmwareRevision');
+    const rebootsTotal = payload.find((item) => item.variable === 'rebootsTotal');
+    const failedTransmitsTotal = payload.find((item) => item.variable === 'failedTransmitsTotal');
+    const errorEventLogsTotal = payload.find((item) => item.variable === 'errorEventLogsTotal');
+    const warningEventLogsTotal = payload.find((item) => item.variable === 'warningEventLogsTotal');
+    const infoEventLogsTotal = payload.find((item) => item.variable === 'infoEventLogsTotal');
+    const measurementPacketsTotal = payload.find((item) => item.variable === 'measurementPacketsTotal');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'batteryLevel', value: 3532 },
-            { variable: 'fatalErrorsTotal', value: 0 },
-            { variable: 'rssiAvg', value: 57 },
-            { variable: 'failedJoinAttemptsTotal', value: 0 },
-            { variable: 'configUpdateOccurred', value: 0 },
-            { variable: 'firmwareRevision', value: 0 },
-            { variable: 'rebootsTotal', value: 3 },
-            { variable: 'failedTransmitsTotal', value: 0 },
-            { variable: 'errorEventLogsTotal', value: 0 },
-            { variable: 'warningEventLogsTotal', value: 0 },
-            { variable: 'infoEventLogsTotal', value: 0 },
-            { variable: 'measurementPacketsTotal', value: 4 },
-            { variable: 'fport', value: 20 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Heartbeat 2.0' }
-        ]);
+        expect(batteryLevel.value).toBe(3532);
+        expect(fatalErrorsTotal.value).toBe(0);
+        expect(rssiAvg.value).toBe(57);
+        expect(failedJoinAttemptsTotal.value).toBe(0);
+        expect(configUpdateOccurred.value).toBe(0);
+        expect(firmwareRevision.value).toBe(0);
+        expect(rebootsTotal.value).toBe(3);
+        expect(failedTransmitsTotal.value).toBe(0);
+        expect(errorEventLogsTotal.value).toBe(0);
+        expect(warningEventLogsTotal.value).toBe(0);
+        expect(infoEventLogsTotal.value).toBe(0);
+        expect(measurementPacketsTotal.value).toBe(4);
+        expect(fport.value).toBe(20);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Heartbeat 2.0');
     });
 });
+
 describe(`fPort: ${testPayloads.data[10].fport} - ${testPayloads.data[10].name}`, () => { // fPort 30
     const raw_payload = [
         { variable: "payload", value: testPayloads.data[10].payload },
@@ -265,8 +388,22 @@ describe(`fPort: ${testPayloads.data[10].fport} - ${testPayloads.data[10].name}`
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+
+    const adcTemperature = payload.find((item) => item.variable === 'ADC Temperature');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual({ variable: 'ADC Temperature', value: 26.375, units: 'C' });
+        expect(adcTemperature.value).toBe(26.375);
+        expect(adcTemperature.units).toBe("C")
+        expect(fport.value).toBe(30);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('One Analog Input');
     });
 });
 
@@ -278,11 +415,25 @@ describe(`fPort: ${testPayloads.data[11].fport} - ${testPayloads.data[11].name}`
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+
+    const ain1 = payload.find((item) => item.variable === 'AIN1');
+    const ain2 = payload.find((item) => item.variable === 'AIN2');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'AIN1', value: 9.999750137329102, units: 'mA' },
-            { variable: 'AIN2', value: 2.5325000286102295, units: 'V' }
-        ]);
+        expect(ain1.value).toBe(9.999750137329102);
+        expect(ain1.units).toBe('mA');
+        expect(ain2.value).toBe(2.5325000286102295);
+        expect(ain2.units).toBe('V');
+        expect(fport.value).toBe(40);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Two Analog Inputs');
     });
 });
 
@@ -294,16 +445,26 @@ describe(`fPort: ${testPayloads.data[12].fport} - ${testPayloads.data[12].name}`
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const wkup = payload.find((item) => item.variable === 'WKUP');
+    const din1 = payload.find((item) => item.variable === 'DIN1');
+    const din2 = payload.find((item) => item.variable === 'DIN2');
+    const din3 = payload.find((item) => item.variable === 'DIN3');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'WKUP', value: 0 },
-            { variable: 'DIN1', value: 1 },
-            { variable: 'DIN2', value: 1 },
-            { variable: 'DIN3', value: 1 },
-            { variable: 'fport', value: 50 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Digital Inputs' }
-        ]);
+        expect(wkup.value).toBe(0);
+        expect(din1.value).toBe(1);
+        expect(din2.value).toBe(1);
+        expect(din3.value).toBe(1);
+        expect(fport.value).toBe(50);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Digital Inputs');
     });
 });
 
@@ -315,15 +476,24 @@ describe(`fPort: ${testPayloads.data[13].fport} - ${testPayloads.data[13].name}`
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const eventTimestamp = payload.find((item) => item.variable === 'eventTimestamp');
+    const eventCode = payload.find((item) => item.variable === 'eventCode');
+    const metadata = payload.find((item) => item.variable === 'metadata');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'eventTimestamp', value: 1690115688 },
-            { variable: 'eventCode', value: 65535 },
-            { variable: 'metadata', value: [0, 0, 0, 0, 0] },
-            { variable: 'fport', value: 60 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Event Log' }
-        ]);
+        expect(eventTimestamp.value).toBe(1690115688);
+        expect(eventCode.value).toBe(65535);
+        expect(metadata.value).toStrictEqual([0, 0, 0, 0, 0]);
+        expect(fport.value).toBe(60);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Event Log');
     });
 });
 
@@ -335,31 +505,56 @@ describe(`fPort: ${testPayloads.data[14].fport} - ${testPayloads.data[14].name}`
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const subgroupID = payload.find((item) => item.variable === 'subgroupID');
+    const sequenceNumber = payload.find((item) => item.variable === 'sequenceNumber');
+    const transRejoin = payload.find((item) => item.variable === 'transRejoin');
+    const ackFrequency = payload.find((item) => item.variable === 'ackFrequency');
+    const lowBattery = payload.find((item) => item.variable === 'lowBattery');
+    const reserved1 = payload.find((item) => item.variable === 'reserved1');
+    const heartbeatAckEnable = payload.find((item) => item.variable === 'heartbeatAckEnable');
+    const operationMode = payload.find((item) => item.variable === 'operationMode');
+    const cycleSubBands = payload.find((item) => item.variable === 'cycleSubBands');
+    const ackRetries = payload.find((item) => item.variable === 'ackRetries');
+    const reservedLL = payload.find((item) => item.variable === 'reservedLL');
+    const ackEnable = payload.find((item) => item.variable === 'ackEnable');
+    const heartbeatEnable = payload.find((item) => item.variable === 'heartbeatEnable');
+    const cycleTime = payload.find((item) => item.variable === 'cycleTime');
+    const backOffReset = payload.find((item) => item.variable === 'backOffReset');
+    const reservedRD = payload.find((item) => item.variable === 'reservedRD');
+    const reserved2 = payload.find((item) => item.variable === 'reserved2');
+    const resendAttempts = payload.find((item) => item.variable === 'resendAttempts');
+    const freqSubBand = payload.find((item) => item.variable === 'freqSubBand');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'subgroupID', value: 0 },
-            { variable: 'sequenceNumber', value: 0 },
-            { variable: 'transRejoin', value: 10 },
-            { variable: 'ackFrequency', value: 4 },
-            { variable: 'lowBattery', value: 3.1 },
-            { variable: 'reserved1', value: 0 },
-            { variable: 'heartbeatAckEnable', value: true },
-            { variable: 'operationMode', value: 1 },
-            { variable: 'cycleSubBands', value: true },
-            { variable: 'ackRetries', value: 2 },
-            { variable: 'reservedLL', value: 4 },
-            { variable: 'ackEnable', value: true },
-            { variable: 'heartbeatEnable', value: true },
-            { variable: 'cycleTime', value: 60 },
-            { variable: 'backOffReset', value: 9 },
-            { variable: 'reservedRD', value: 5 },
-            { variable: 'reserved2', value: 0 },
-            { variable: 'resendAttempts', value: 0 },
-            { variable: 'freqSubBand', value: 2 },
-            { variable: 'fport', value: 70 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Configuration' }
-        ]);
+        expect(subgroupID.value).toBe(0);
+        expect(sequenceNumber.value).toBe(0);
+        expect(transRejoin.value).toBe(10);
+        expect(ackFrequency.value).toBe(4);
+        expect(lowBattery.value).toBe(3.1);
+        expect(reserved1.value).toBe(0);
+        expect(heartbeatAckEnable.value).toBe(true);
+        expect(operationMode.value).toBe(1);
+        expect(cycleSubBands.value).toBe(true);
+        expect(ackRetries.value).toBe(2);
+        expect(reservedLL.value).toBe(4);
+        expect(ackEnable.value).toBe(true);
+        expect(heartbeatEnable.value).toBe(true);
+        expect(cycleTime.value).toBe(60);
+        expect(backOffReset.value).toBe(9);
+        expect(reservedRD.value).toBe(5);
+        expect(reserved2.value).toBe(0);
+        expect(resendAttempts.value).toBe(0);
+        expect(freqSubBand.value).toBe(2);
+        expect(fport.value).toBe(70);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Configuration');
     });
 });
 
@@ -371,13 +566,20 @@ describe(`fPort: ${testPayloads.data[15].fport} - ${testPayloads.data[15].name}`
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const group3register1 = payload.find((item) => item.variable === 'group3register1');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'group3register1', value: 531 },
-            { variable: 'fport', value: 100 },
-            { variable: 'voboType', value: 'VoBoXX' },
-            { variable: 'payloadType', value: 'Modbus Generic' }
-        ]);
+        expect(group3register1.value).toBe(531);
+        expect(fport.value).toBe(100);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Modbus Generic');
     });
 });
 
@@ -390,14 +592,27 @@ describe(`fPort: ${testPayloads.data[16].fport} - ${testPayloads.data[16].name}`
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const ain1 = payload.find((item) => item.variable === 'AIN1');
+    const ain2 = payload.find((item) => item.variable === 'AIN2');
+    const ain3 = payload.find((item) => item.variable === 'AIN3');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'AIN1', value: 1, units: 'ADC code' },
-            { variable: 'AIN2', value: 2, units: 'ADC code' },
-            { variable: 'AIN3', value: 1, units: 'ADC code' },
-            { variable: 'Battery Voltage', value: 3.375999927520752, units: 'V' },
-            { variable: 'ADC Temperature', value: 22.75, units: 'C' }
-        ]);
+        expect(ain1.value).toBe(1);
+        expect(ain1.units).toBe('ADC code');
+        expect(ain2.value).toBe(2);
+        expect(ain2.units).toBe('ADC code');
+        expect(ain3.value).toBe(1);
+        expect(ain3.units).toBe('ADC code');
+        expect(fport.value).toBe(110);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Analog Input Variable Length');
     });
 });
 
@@ -409,16 +624,32 @@ describe(`fPort: ${testPayloads.data[17].fport} - ${testPayloads.data[17].name}`
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const modbus1 = payload.find((item) => item.variable === 'Modbus1');
+    const modbus2 = payload.find((item) => item.variable === 'Modbus2');
+    const modbus3 = payload.find((item) => item.variable === 'Modbus3');
+    const modbus4 = payload.find((item) => item.variable === 'Modbus4');
+    const modbus5 = payload.find((item) => item.variable === 'Modbus5');
+    const modbus6 = payload.find((item) => item.variable === 'Modbus6');
+    const modbus7 = payload.find((item) => item.variable === 'Modbus7');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'Modbus1', value: 9999 },
-            { variable: 'Modbus2', value: 9999 },
-            { variable: 'Modbus3', value: 9999 },
-            { variable: 'Modbus4', value: 9999 },
-            { variable: 'Modbus5', value: 9999 },
-            { variable: 'Modbus6', value: 9999 },
-            { variable: 'Modbus7', value: 9999 }
-        ]);
+        expect(modbus1.value).toBe(9999);
+        expect(modbus2.value).toBe(9999);        
+        expect(modbus3.value).toBe(9999);
+        expect(modbus4.value).toBe(9999);
+        expect(modbus5.value).toBe(9999);
+        expect(modbus6.value).toBe(9999);
+        expect(modbus7.value).toBe(9999);
+        expect(fport.value).toBe(120);
+        expect(voboType.value).toBe('VoBoXX');
+        expect(payloadType.value).toBe('Modbus Standard Variable Length');
     });
 });
 

--- a/decoders/connector/volley-boast/vobo-hl-1/v1.0.0/payload.test.ts
+++ b/decoders/connector/volley-boast/vobo-hl-1/v1.0.0/payload.test.ts
@@ -400,7 +400,7 @@ describe(`fPort: ${testPayloads.data[10].fport} - ${testPayloads.data[10].name}`
 
     test("Check if data is correct", () => {
         expect(adcTemperature.value).toBe(26.375);
-        expect(adcTemperature.units).toBe("C")
+        expect(adcTemperature.unit).toBe("C")
         expect(fport.value).toBe(30);
         expect(voboType.value).toBe('VoBoXX');
         expect(payloadType.value).toBe('One Analog Input');
@@ -428,9 +428,9 @@ describe(`fPort: ${testPayloads.data[11].fport} - ${testPayloads.data[11].name}`
 
     test("Check if data is correct", () => {
         expect(ain1.value).toBe(9.999750137329102);
-        expect(ain1.units).toBe('mA');
+        expect(ain1.unit).toBe('mA');
         expect(ain2.value).toBe(2.5325000286102295);
-        expect(ain2.units).toBe('V');
+        expect(ain2.unit).toBe('V');
         expect(fport.value).toBe(40);
         expect(voboType.value).toBe('VoBoXX');
         expect(payloadType.value).toBe('Two Analog Inputs');
@@ -605,11 +605,11 @@ describe(`fPort: ${testPayloads.data[16].fport} - ${testPayloads.data[16].name}`
 
     test("Check if data is correct", () => {
         expect(ain1.value).toBe(1);
-        expect(ain1.units).toBe('ADC code');
+        expect(ain1.unit).toBe('ADC code');
         expect(ain2.value).toBe(2);
-        expect(ain2.units).toBe('ADC code');
+        expect(ain2.unit).toBe('ADC code');
         expect(ain3.value).toBe(1);
-        expect(ain3.units).toBe('ADC code');
+        expect(ain3.unit).toBe('ADC code');
         expect(fport.value).toBe(110);
         expect(voboType.value).toBe('VoBoXX');
         expect(payloadType.value).toBe('Analog Input Variable Length');

--- a/decoders/connector/volley-boast/vobo-tc/v1.0.0/payload.js
+++ b/decoders/connector/volley-boast/vobo-tc/v1.0.0/payload.js
@@ -8,11 +8,19 @@ function customDecoder(bytes, fport) {
     //=======================================================
     // Insert your customization here
     if (fport == 31) {
-        var tagoDecoded = {
+        var tagoDecoded = [
+            {
             variable: decoded.data.analogSensorString0,
             value: decoded.data.sensorData0,
             units: decoded.data.engUnitsString0
-        }
+            }
+        ];        
+        tagoDecoded.push(
+            { variable: "fport", value: decoded.data.fport },
+            { variable: "voboType", value: decoded.data.voboType },
+            { variable: "payloadType", value: decoded.data.payloadType }
+        );
+
     }
     else if (fport == 41) {
         var tagoDecoded = [
@@ -26,14 +34,18 @@ function customDecoder(bytes, fport) {
                 value: decoded.data.sensorData1,
                 units: decoded.data.engUnitsString1
             }
-        ]
+        ];  
+        tagoDecoded.push(
+            { variable: "fport", value: decoded.data.fport },
+            { variable: "voboType", value: decoded.data.voboType },
+            { variable: "payloadType", value: decoded.data.payloadType }
+        );
     }
     else if (fport == 51) {
         var tagoDecoded = decoded.data.digitalSensorStrings.map((sensor, index) => ({
             variable: sensor,
             value: decoded.data.digitalSensorData[index]
         }));
-
         tagoDecoded.push(
             { variable: "fport", value: decoded.data.fport },
             { variable: "voboType", value: decoded.data.voboType },
@@ -46,6 +58,11 @@ function customDecoder(bytes, fport) {
             value: payloadObj.sensorData0,
             units: decoded.data[`engUnitsString${index}`]
         }));
+        tagoDecoded.push(
+            { variable: "fport", value: decoded.data.fport },
+            { variable: "voboType", value: decoded.data.voboType },
+            { variable: "payloadType", value: decoded.data.payloadType }
+        );
     }
     else {
         var tagoDecoded = Object.entries(decoded.data).map(([key, value]) => ({
@@ -57,13 +74,13 @@ function customDecoder(bytes, fport) {
     return tagoDecoded;
 }
 
-const DECODER_MAJOR_VERSION=2,DECODER_MINOR_VERSION=1,DECODER_PATCH_VERSION=1;function decodeUplink(a){return Decoder(a.bytes,a.fPort)}
-function Decoder(a,b){var c={},d=[];1==b?c=parseStandardPayload(a):2<=b&&9>=b?c=parseModbusStandardPayload(a,b):10==b?c=parseHeartbeat1p0Payload(a):20<=b&&29>=b?c=parseHeartbeat2p0Payload(a):30<=b&&39>=b?c=parseOneAnalogSensorPayload(a):40<=b&&49>=b?c=parseTwoAnalogSensorsPayload(a):50<=b&&59>=b?c=parseDigitalSensorsPayload(a):60<=b&&69>=b?c=parseEventLogPayload(a):70<=b&&79>=b?c=parseConfigurationPayload(a,b):100<=b&&109>=b?c=parseModbusGenericPayload(a,b):110<=b&&119>=b?c=parseAnalogInputVariableLengthPayload(a,
-b):120<=b&&129>=b?c=parseModbusStandardVariableLengthPayload(a,b):d.push("unknown FPort");a=addVoboMetadata(c,b);a.warnings=[];a.errors=d;return a}
+const DECODER_MAJOR_VERSION=2,DECODER_MINOR_VERSION=2,DECODER_PATCH_VERSION=0;function decodeUplink(a){return Decoder(a.bytes,a.fPort)}
+function Decoder(a,b){var c={},d=[];1==b?c=parseStandardPayload(a):2<=b&&9>=b?c=parseModbusStandardPayload(a,b):10==b?c=parseHeartbeat1p0Payload(a):20<=b&&29>=b?c=parseHeartbeat2p0Payload(a):30<=b&&39>=b?c=parseOneAnalogSensorPayload(a):40<=b&&49>=b?c=parseTwoAnalogSensorsPayload(a):50<=b&&59>=b?c=parseDigitalSensorsPayload(a):60<=b&&69>=b?c=parseEventLogPayload(a):70<=b&&79>=b?c=parseConfigurationPayload(a,b):80<=b&&89>=b?c=parseEventLogPayload(a):100<=b&&109>=b?c=parseModbusGenericPayload(a,b):
+110<=b&&119>=b?c=parseAnalogInputVariableLengthPayload(a,b):120<=b&&129>=b?c=parseModbusStandardVariableLengthPayload(a,b):d.push("unknown FPort");a=addVoboMetadata(c,b);a.warnings=[];a.errors=d;return a}
 function addVoboMetadata(a,b){var c={};c.data=a;var d=a="",e=b%10;0==e||1<=b&&10>b?a="VoBoXX":1==e?a="VoBoTC":2==e&&(a="VoBoXP");if(1==b)d="Standard";else if(2<=b&&9>=b)d="Modbus Standard";else if(10==b)d="Heartbeat 1.0";else if(20<=b&&29>=b)d="Heartbeat 2.0";else if(30<=b&&39>=b)d="One Analog Input",c.data.analogSensorString0=lookupAnalogSensorName(a,c.data.sensorNum0),c.data.engUnitsString0=lookupUnits(1,c.data.sensorUnits0);else if(40<=b&&49>=b)d="Two Analog Inputs",c.data.analogSensorString0=
 lookupAnalogSensorName(a,c.data.sensorNum0),c.data.engUnitsString0=lookupUnits(1,c.data.sensorUnits0),c.data.analogSensorString1=lookupAnalogSensorName(a,c.data.sensorNum1),c.data.engUnitsString1=lookupUnits(1,c.data.sensorUnits1);else if(50<=b&&59>=b)for(d="Digital Inputs",c.data.digitalSensorStrings=[],c.data.digitalSensorData=[],e=0;16>e;e++)1==(c.data.sensorValid0>>e&1)&&(c.data.digitalSensorStrings.push(lookupDigitalSensorName(a,e)),c.data.digitalSensorData.push(c.data.sensorData0>>e&1));else if(60<=
-b&&69>=b)d="Event Log";else if(70<=b&&79>=b)d="Configuration";else if(100<=b&&109>=b)d="Modbus Generic";else if(110<=b&&119>=b)for(d="Analog Input Variable Length",e=0;e<c.data.numOfAinPayloads;e++)c.data["analogSensorString"+e]=lookupAnalogSensorName(a,c.data.ainPayloads[e].sensorNum0),c.data["engUnitsString"+e]=lookupUnits(1,c.data.ainPayloads[e].sensorUnits0);else 120<=b&&129>=b&&(d="Modbus Standard Variable Length");c.data.fport=b;c.data.voboType=a;c.data.payloadType=d;return c}
-function parseStandardPayload(a){var b={};b.DIN1=a[0]&1;b.DIN2=a[0]>>1&1;b.DIN3=a[0]>>2&1;b.WKUP=a[0]>>3&1;b.ADC1=(a[0]&240)>>4|a[1]<<4;b.ADC2=(a[3]&15)<<8|a[2];b.ADC3=(a[3]&240)>>4|a[4]<<4;b.Battery=4*((a[6]&15)<<8|a[5]);b.Temperature=0==(a[7]>>7&1)?.125*((a[6]&240)>>4|a[7]<<4):-.125*(4096-((a[6]&240)>>4|a[7]<<4));b.Modbus0=a[9]<<8|a[8];return b}
+b&&69>=b)d="Event Log";else if(70<=b&&79>=b)d="Configuration";else if(80<=b&&89>=b)d="Notification";else if(100<=b&&109>=b)d="Modbus Generic";else if(110<=b&&119>=b)for(d="Analog Input Variable Length",e=0;e<c.data.numOfAinPayloads;e++)c.data["analogSensorString"+e]=lookupAnalogSensorName(a,c.data.ainPayloads[e].sensorNum0),c.data["engUnitsString"+e]=lookupUnits(1,c.data.ainPayloads[e].sensorUnits0);else 120<=b&&129>=b&&(d="Modbus Standard Variable Length");c.data.fport=b;c.data.voboType=a;c.data.payloadType=
+d;return c}function parseStandardPayload(a){var b={};b.DIN1=a[0]&1;b.DIN2=a[0]>>1&1;b.DIN3=a[0]>>2&1;b.WKUP=a[0]>>3&1;b.ADC1=(a[0]&240)>>4|a[1]<<4;b.ADC2=(a[3]&15)<<8|a[2];b.ADC3=(a[3]&240)>>4|a[4]<<4;b.Battery=4*((a[6]&15)<<8|a[5]);b.Temperature=0==(a[7]>>7&1)?.125*((a[6]&240)>>4|a[7]<<4):-.125*(4096-((a[6]&240)>>4|a[7]<<4));b.Modbus0=a[9]<<8|a[8];return b}
 function parseModbusStandardPayload(a,b){b=5*(b-1)-4;var c={};c["Modbus"+b++]=a[1]<<8|a[0];c["Modbus"+b++]=a[3]<<8|a[2];c["Modbus"+b++]=a[5]<<8|a[4];c["Modbus"+b++]=a[7]<<8|a[6];c["Modbus"+b]=a[9]<<8|a[8];return c}
 function parseHeartbeat1p0Payload(a){var b={};b.batteryLevelMV=4*((a[1]&15)<<8|a[0]);b.fwVersionMajor=a[2]&15|(a[1]&240)>>4;b.fwVersionMinor=a[3]&15|(a[2]&240)>>4;b.fwVersionPatch=a[4]&15|(a[3]&240)>>4;b.fwVersionCustom=(a[4]&240)>>4;b.recSignalLevels=-1*a[5];b.analogVoltageConfig=a[6]&31;b.analogPowerTimeConfig=parseFloat((((a[7]&31)<<3|(a[6]&224)>>5)/10).toFixed(1));b.failedTransmissionBeforeRejoinConfig=(a[8]&1)<<3|(a[7]&224)>>5;b.cycleThroughFSB=(a[8]&2)>>1;b.ackEnable=(a[8]&4)>>2;b.ackFreq=(a[8]&
 120)>>3;b.ackReq=(a[9]&7)<<1|(a[8]&128)>>7;b.batteryLevelThreshold=4*((a[10]&127)<<5|(a[9]&248)>>3);return b}
@@ -71,8 +88,8 @@ function parseHeartbeat2p0Payload(a){var b={};b.batteryLevel=(a[1]&15)<<8|a[0];b
 function bytesToFloat32(a){var b=new ArrayBuffer(4),c=new Uint8Array(b);c[0]=a[0];c[1]=a[1];c[2]=a[2];c[3]=a[3];return(new DataView(b)).getFloat32(0,!1)}function parseOneAnalogSensorPayload(a){var b={};b.sensorNum0=a[0];b.sensorUnits0=a[1];b.sensorData0=bytesToFloat32(a.slice(2,6));return b}
 function parseTwoAnalogSensorsPayload(a){var b={};b.sensorNum0=(a[0]&240)>>4;b.sensorUnits0=a[1];b.sensorData0=bytesToFloat32(a.slice(2,6));b.sensorNum1=a[0]&15;b.sensorUnits1=a[6];b.sensorData1=bytesToFloat32(a.slice(7,11));return b}function parseDigitalSensorsPayload(a){var b={};b.sensorValid0=a[1]<<8|a[0];b.sensorData0=a[3]<<8|a[2];return b}
 function parseEventLogPayload(a){var b={};b.eventTimestamp=a[0]+a[1]*Math.pow(2,8)+a[2]*Math.pow(2,16)+a[3]*Math.pow(2,24);b.eventCode=a[4]+a[5]*Math.pow(2,8);b.metadata=Array.prototype.slice.call(a.slice(6,11),0);return b}
-function parseVoboLibGeneralConfigurationPayload(a){var b={};b.subgroupID=a[0]&15;b.sequenceNumber=(a[0]&240)>>4;0==b.sequenceNumber&&(b.transRejoin=a[1]&15,b.ackFrequency=(a[1]&240)>>4,b.lowBattery=parseFloat(((a[2]&15)/10+2.5).toFixed(1)),b.reserved1=(a[2]&16)>>4,b.heartbeatAckEnable=!!((a[2]&32)>>5),b.operationMode=(a[2]&64)>>6,b.cycleSubBands=!!((a[2]&128)>>7),b.ackRetries=a[3]&7,b.reservedLL=(a[3]&56)>>3,b.ackEnable=!!((a[3]&64)>>6),b.heartbeatEnable=!!((a[3]&128)>>7),b.cycleTime=(a[6]&3)<<16|
-a[5]<<8|a[4],b.backOffReset=(a[6]&252)>>2,b.reservedRD=a[7]&63,b.reserved2=(a[7]&192)>>6,b.resendAttempts=a[8]&15,b.freqSubBand=(a[8]&240)>>4);if(1==b.sequenceNumber){b.timeSyncInterval=a[1];b.joinEUI="";for(let c=9;2<=c;c--)b.joinEUI+=a[c].toString(16).toUpperCase().padStart(2,0),2!=c&&(b.joinEUI+="-");b.joinNonceResetEnable=!!(a[10]&1);b.timeSyncWakeupEnable=!!((a[10]&2)>>1);b.reserved1=(a[10]&252)>>2}return b}
+function parseVoboLibGeneralConfigurationPayload(a,b){var c={};c.subgroupID=a[0]&15;c.sequenceNumber=(a[0]&240)>>4;0==c.sequenceNumber&&(c.transRejoin=a[1]&15,c.ackFrequency=(a[1]&240)>>4,70==b||71==b?c.lowBattery=parseFloat(((a[2]&15)/10+2.5).toFixed(1)):72==b&&(c.lowVoltThreshold=parseFloat(((a[2]&15)/10+2.5).toFixed(1))),c.reserved1=(a[2]&16)>>4,c.heartbeatAckEnable=!!((a[2]&32)>>5),c.operationMode=(a[2]&64)>>6,c.cycleSubBands=!!((a[2]&128)>>7),c.ackRetries=a[3]&7,c.reservedLL=(a[3]&56)>>3,c.ackEnable=
+!!((a[3]&64)>>6),c.heartbeatEnable=!!((a[3]&128)>>7),c.cycleTime=(a[6]&3)<<16|a[5]<<8|a[4],c.backOffReset=(a[6]&252)>>2,c.reservedRD=a[7]&63,c.reserved2=(a[7]&192)>>6,c.resendAttempts=a[8]&15,c.freqSubBand=(a[8]&240)>>4);if(1==c.sequenceNumber){c.timeSyncInterval=a[1];c.joinEUI="";for(b=9;2<=b;b--)c.joinEUI+=a[b].toString(16).toUpperCase().padStart(2,0),2!=b&&(c.joinEUI+="-");c.joinNonceResetEnable=!!(a[10]&1);c.timeSyncWakeupEnable=!!((a[10]&2)>>1);c.reserved1=(a[10]&252)>>2}return c}
 function parseVoboLibVoboSyncConfigurationPayload(a){var b={};b.subgroupID=a[0]&15;b.sequenceNumber=(a[0]&240)>>4;0==b.sequenceNumber&&(b.vbsNodeNumber=a[2]<<8|a[1],b.vbsTimeReference=a.slice(3,7).readUInt32LE(),b.reservedVCPDS=a[7]&15,b.reservedVMPDS=(a[7]&240)>>4,b.reservedVUDS=a[8]&15,b.reserved1=(a[8]&48)>>4,b.reservedVSAE=!!((a[8]&64)>>6),b.vbsEnable=!!((a[8]&128)>>7),b.reserved3=a[9]&63,b.reserved2=(a[9]&192)>>6);1==b.sequenceNumber&&(b.vbsMeasurementDelaySec=a[1]&127,b.reserved1=(a[1]&128)>>
 7,b.vbsUplinkDelaySec=a[2]&127,b.reserved2=(a[2]&128)>>7);return b}
 function parseVoboXXGeneralConfigurationPayload(a){var b={};b.subgroupID=a[0]&15;b.sequenceNumber=(a[0]&240)>>4;b.analogVoltage=parseFloat((a[1]/10).toFixed(1));b.powerTime=parseFloat((a[2]/10).toFixed(1));b.mbEnable=!!(a[3]&1);b.engUnitsEnable=!!(a[3]>>1&1);b.din1TransmitEnable=!!(a[3]>>2&1);b.din2TransmitEnable=!!(a[3]>>3&1);b.din3TransmitEnable=!!(a[3]>>4&1);b.wkupTransmitEnable=!!(a[3]>>5&1);b.ain1TransmitEnable=!!(a[3]>>6&1);b.ain2TransmitEnable=!!(a[3]>>7&1);b.ain3TransmitEnable=!!(a[4]&1);
@@ -104,8 +121,14 @@ function parseVoboTCCalibrationConfigurationPayload(a){var b={};b.subgroupID=a[0
 b.reserved2=(a[4]&128)>>7,b.gain6=parseFloat((((a[6]&7)<<8|a[5])/1E3).toFixed(3)),b.reserved3=(a[6]&248)>>3,b.offset6=parseFloat((((a[8]&127)<<8|a[7])/1E3-10).toFixed(3)),b.reserved4=(a[8]&128)>>7);3==b.sequenceNumber&&(b.gain7=parseFloat((((a[2]&7)<<8|a[1])/1E3).toFixed(3)),b.reserved1=(a[2]&248)>>3,b.offset7=parseFloat((((a[4]&127)<<8|a[3])/1E3-10).toFixed(3)),b.reserved2=(a[4]&128)>>7,b.gain8=parseFloat((((a[6]&7)<<8|a[5])/1E3).toFixed(3)),b.reserved3=(a[6]&248)>>3,b.offset8=parseFloat((((a[8]&
 127)<<8|a[7])/1E3-10).toFixed(3)),b.reserved4=(a[8]&128)>>7);4==b.sequenceNumber&&(b.gain9=parseFloat((((a[2]&7)<<8|a[1])/1E3).toFixed(3)),b.reserved1=(a[2]&248)>>3,b.offset9=parseFloat((((a[4]&127)<<8|a[3])/1E3-10).toFixed(3)),b.reserved2=(a[4]&128)>>7,b.gain10=parseFloat((((a[6]&7)<<8|a[5])/1E3).toFixed(3)),b.reserved3=(a[6]&248)>>3,b.offset10=parseFloat((((a[8]&127)<<8|a[7])/1E3-10).toFixed(3)),b.reserved4=(a[8]&128)>>7);5==b.sequenceNumber&&(b.gain11=parseFloat((((a[2]&7)<<8|a[1])/1E3).toFixed(3)),
 b.reserved1=(a[2]&248)>>3,b.offset11=parseFloat((((a[4]&127)<<8|a[3])/1E3-10).toFixed(3)),b.reserved2=(a[4]&128)>>7,b.gain12=parseFloat((((a[6]&7)<<8|a[5])/1E3).toFixed(3)),b.reserved3=(a[6]&248)>>3,b.offset12=parseFloat((((a[8]&127)<<8|a[7])/1E3-10).toFixed(3)),b.reserved4=(a[8]&128)>>7);return b}
-function parseConfigurationPayload(a,b){var c={},d=a[0]&15;0==d?c=parseVoboLibGeneralConfigurationPayload(a):1==d?c=parseVoboLibVoboSyncConfigurationPayload(a):70==b&&4==d?c=parseVoboXXGeneralConfigurationPayload(a):70==b&&5==d?c=parseVoboXXModbusGeneralConfigurationPayload(a):70!=b||6!=d&&7!=d?70!=b||8!=d&&9!=d&&10!=d?70==b&&11==d?c=parseVoboXXModbusPayloadsSlotsConfigurationPayload(a):70==b&&12==d?c=parseVoboXXEngineeringUnitsConfigurationPayload(a):71==b&&4==d?c=parseVoboTCGeneralConfigurationPayload(a):
-71==b&&5==d&&(c=parseVoboTCCalibrationConfigurationPayload(a)):c=parseVoboXXModbusGroupsConfigurationPayload(a):c=parseVoboXXModbusGroupsEnableConfigurationPayload(a);return c}
+function parseVoboXPGeneralConfigurationPayload(a){var b={};b.subgroupID=a[0]&15;b.sequenceNumber=(a[0]&240)>>4;0==b.sequenceNumber&&(b.analogVoltage=parseFloat((a[1]/10).toFixed(1)),b.powerTime=parseFloat((a[2]/10).toFixed(1)),b.mbEnable=!!(a[3]&1),b.reserved1=a[3]>>1&127,b.reserved2=a[4]&7,b.mbTransmitEnable=!!(a[4]>>3&1),b.ainPayloadType=a[4]>>4&1,b.reservedMAWE=!!(a[4]>>5&1),b.reservedMADE=!!(a[4]>>6&1),b.reservedMAME=!!(a[4]>>7&1),b.reservedDTC=a[6]<<8|a[5]);1==b.sequenceNumber&&(b.stateRLY1=
+a[1]&1,b.stateRLY2=a[1]>>1&1,b.stateRLY3=a[1]>>2&1,b.stateRLY4=a[1]>>3&1,b.reserved1=a[1]>>4&15,b.lorawanClass=a[2]&1,b.contMeasEnable=!!(a[2]>>1&1),b.reservedARDE=!!(a[2]>>2&1),b.pFailWarnEnable=!!(a[2]>>3&1),b.pcntDin1Enable=!!(a[2]>>4&1),b.pcntDin2Enable=!!(a[2]>>5&1),b.reserved2=a[2]>>6&3,b.pcntDin1Type=a[3]&3,b.pcntDin2Type=a[3]>>2&3,b.reserved3=a[3]>>4&15,b.pcntPeriod=a[4]&63,b.reserved4=a[4]>>6&3,b.contMeasCycleTime=a[5]&63,b.reserved5=a[5]>>6&3,b.pFailThreshold=parseFloat((a[6]/10).toFixed(1)),
+b.serialPHY=a[7]&1,b.reserved6=a[7]>>1&7,b.serialProtoRS485=a[7]>>4&1,b.reserved7=a[7]>>5&1,b.serialProtoRS232=a[7]>>6&1,b.reserved8=a[7]>>7&1);return b}
+function parseVoboXPTransmitEncodingConfigurationPayload(a){var b={};b.subgroupID=a[0]&15;b.sequenceNumber=(a[0]&240)>>4;b.txAin1=a[1]&15;b.txAin2=a[1]>>4&15;b.txAin3=a[2]&15;b.txDin1=a[2]>>4&15;b.txDin2=a[3]&15;b.txPcntDin1=a[3]>>4&15;b.txPcntDin2=a[4]&15;b.txWKUP=a[4]>>4&15;b.txTemp=a[5]&15;b.txVoltRLY1=a[5]>>4&15;b.txVoltRLY2=a[6]&15;b.txVoltRLY3=a[6]>>4&15;b.txVoltRLY4=a[7]&15;b.txVoltVIN=a[7]>>4&15;b.txVolt3V3=a[8]&15;b.txVoltVPP=a[8]>>4&15;b.txContMeasPeriod=a[9]&15;b.txContMeasCnt=a[9]>>4&
+1;b.reserved1=a[9]>>5&7;return b}function parseVoboXPRelayPulseConfigurationPayload(a){var b={};b.subgroupID=a[0]&15;b.sequenceNumber=(a[0]&240)>>4;0==b.sequenceNumber?(b.pulseDelayRLY1=a[2]<<8|a[1],b.pulsePeriodRLY1=a[4]<<8|a[3],b.pulseDelayRLY2=a[6]<<8|a[5],b.pulsePeriodRLY2=a[8]<<8|a[7]):1==b.sequenceNumber&&(b.pulseDelayRLY3=a[2]<<8|a[1],b.pulsePeriodRLY3=a[4]<<8|a[3],b.pulseDelayRLY4=a[6]<<8|a[5],b.pulsePeriodRLY4=a[8]<<8|a[7]);return b}
+function parseConfigurationPayload(a,b){var c={},d=a[0]&15;0==d?c=parseVoboLibGeneralConfigurationPayload(a,b):1==d?c=parseVoboLibVoboSyncConfigurationPayload(a):70==b&&4==d?c=parseVoboXXGeneralConfigurationPayload(a):70==b&&5==d?c=parseVoboXXModbusGeneralConfigurationPayload(a):70!=b||6!=d&&7!=d?70!=b||8!=d&&9!=d&&10!=d?70==b&&11==d?c=parseVoboXXModbusPayloadsSlotsConfigurationPayload(a):70==b&&12==d?c=parseVoboXXEngineeringUnitsConfigurationPayload(a):71==b&&4==d?c=parseVoboTCGeneralConfigurationPayload(a):
+71==b&&5==d?c=parseVoboTCCalibrationConfigurationPayload(a):72==b&&4==d?c=parseVoboXPGeneralConfigurationPayload(a):72==b&&5==d?c=parseVoboXXModbusGeneralConfigurationPayload(a):72!=b||6!=d&&7!=d?72!=b||8!=d&&9!=d&&10!=d?72==b&&11==d?c=parseVoboXXModbusPayloadsSlotsConfigurationPayload(a):72==b&&12==d?c=parseVoboXXEngineeringUnitsConfigurationPayload(a):72==b&&13==d?c=parseVoboXPTransmitEncodingConfigurationPayload(a):72==b&&14==d&&(c=parseVoboXPRelayPulseConfigurationPayload(a)):c=parseVoboXXModbusGroupsConfigurationPayload(a):
+c=parseVoboXXModbusGroupsEnableConfigurationPayload(a):c=parseVoboXXModbusGroupsConfigurationPayload(a):c=parseVoboXXModbusGroupsEnableConfigurationPayload(a);return c}
 function parseModbusGenericPayload(a,b){b={};for(var c=a.length,d=0;d<c-1;){var e=a[d]&63;if(0<e){var f=a[d]>>6&3;d++;if(0==f){var g=a[d+1]<<8|a[d];b["group"+e+"register1"]=g;d+=2}else if(1==f)b["group"+e+"register1"]=a[d+1]<<8|a[d],b["group"+e+"register2"]=a[d+3]<<8|a[d+2],d+=4;else if(2==f){f=[];var h=a[d]&127;d++;for(var k=0;k<h;k++)g=a[d+1]<<8|a[d],b["group"+e+"register"+(k+1)]=g,f.push(g),d+=2}else if(3==f){f=[];h=a[d]&127;d++;k=a[d]&127;d++;h-=k;g=Math.floor((c-d)/2);h>g&&(h=g);for(let l=0;l<
 h;l++)g=a[d+1]<<8|a[d],b["group"+e+"register"+(k+l+1)]=g,f.push(g),d+=2}}else break}return b}function parseAnalogInputVariableLengthPayload(a,b){b={};for(var c=[],d=a.length,e=0;e<d;){var f=a.slice(e,e+6);f=parseOneAnalogSensorPayload(f);c.push(f);e+=6}b.ainPayloads=c;b.numOfAinPayloads=c.length;return b}
 function parseModbusStandardVariableLengthPayload(a,b){b={};for(var c={},d=a.length,e=a[d-1],f=0;f<d-1;)c["Modbus"+(e+f/2)]=a[f+1]<<8|a[f],f+=2;b.modbusSlots=c;b.firstSlotNum=e;b.numModbusSlots=(d-1)/2;return b}
@@ -113,8 +136,8 @@ function lookupAnalogSensorName(a,b){var c=[{"Analog Sensor Number":"0","Analog 
 "Analog Sensor Name":"TC2"},{"Analog Sensor Number":"3","Analog Sensor Name":"TC3"},{"Analog Sensor Number":"4","Analog Sensor Name":"TC4"},{"Analog Sensor Number":"5","Analog Sensor Name":"TC5"},{"Analog Sensor Number":"6","Analog Sensor Name":"TC6"},{"Analog Sensor Number":"7","Analog Sensor Name":"TC7"},{"Analog Sensor Number":"8","Analog Sensor Name":"TC8"},{"Analog Sensor Number":"9","Analog Sensor Name":"TC9"},{"Analog Sensor Number":"10","Analog Sensor Name":"TC10"},{"Analog Sensor Number":"11",
 "Analog Sensor Name":"TC11"},{"Analog Sensor Number":"12","Analog Sensor Name":"TC12"},{"Analog Sensor Number":"13","Analog Sensor Name":"Cold Joint Temperature"}],e=[{"Analog Sensor Number":"0","Analog Sensor Name":"3.3V Supply Voltage"},{"Analog Sensor Number":"1","Analog Sensor Name":"AIN1"},{"Analog Sensor Number":"2","Analog Sensor Name":"AIN2"},{"Analog Sensor Number":"3","Analog Sensor Name":"AIN3"},{"Analog Sensor Number":"4","Analog Sensor Name":"DIN1"},{"Analog Sensor Number":"5","Analog Sensor Name":"DIN1 Pulse Count"},
 {"Analog Sensor Number":"6","Analog Sensor Name":"DIN2"},{"Analog Sensor Number":"7","Analog Sensor Name":"DIN2 Pulse Count"},{"Analog Sensor Number":"8","Analog Sensor Name":"RLY1 Voltage"},{"Analog Sensor Number":"9","Analog Sensor Name":"RLY2 Voltage"},{"Analog Sensor Number":"10","Analog Sensor Name":"RLY3 Voltage"},{"Analog Sensor Number":"11","Analog Sensor Name":"RLY4 Voltage"},{"Analog Sensor Number":"12","Analog Sensor Name":"WKUP"},{"Analog Sensor Number":"13","Analog Sensor Name":"VPP Voltage"},
-{"Analog Sensor Number":"14","Analog Sensor Name":"VIN Voltage"},{"Analog Sensor Number":"15","Analog Sensor Name":"ADC Temperature"},{"Analog Sensor Number":"16","Analog Sensor Name":"Cont Meas Period"},{"Analog Sensor Number":"17","Analog Sensor Name":"Cont Meas Count"}];var f=[],g="";if("VoBoXX"==a)f=c;else if("VoBoTC"==a)f=d;else if("VoBoXP"==a)f=e,c=(b&192)>>6,1==c?g="(Max)":2==c?g="(Min)":3==c&&(g="(Avg)"),b&=63;else throw errorMsg=a+' -- Invalid VoBo Type. Use "VoBoXX", "VoBoTC" or "VoBoXP"',
-Error(errorMsg);f=f.find(h=>h["Analog Sensor Number"]==b.toString());if("undefined"==typeof f)return"AnalogSensor"+b.toString();f=f["Analog Sensor Name"];"VoBoXP"==a&&(f=f+" "+g);return f}
+{"Analog Sensor Number":"14","Analog Sensor Name":"VIN Voltage"},{"Analog Sensor Number":"15","Analog Sensor Name":"ADC Temperature"},{"Analog Sensor Number":"16","Analog Sensor Name":"Cont Meas Period"},{"Analog Sensor Number":"17","Analog Sensor Name":"Cont Meas Count"}];var f=[],g="";if("VoBoXX"==a)f=c;else if("VoBoTC"==a)f=d;else if("VoBoXP"==a)f=e,c=(b&192)>>6,1==c?g=" (Max)":2==c?g=" (Min)":3==c&&(g=" (Avg)"),b&=63;else throw errorMsg=a+' -- Invalid VoBo Type. Use "VoBoXX", "VoBoTC" or "VoBoXP"',
+Error(errorMsg);f=f.find(h=>h["Analog Sensor Number"]==b.toString());if("undefined"==typeof f)return"AnalogSensor"+b.toString();f=f["Analog Sensor Name"];"VoBoXP"==a&&(f+=g);return f}
 function lookupDigitalSensorName(a,b){const c=[{"Digital Sensor Number":"0","Digital Sensor Name":"WKUP"},{"Digital Sensor Number":"1","Digital Sensor Name":"DIN1"},{"Digital Sensor Number":"2","Digital Sensor Name":"DIN2"},{"Digital Sensor Number":"3","Digital Sensor Name":"DIN3"}],d=[{"Digital Sensor Number":"0","Digital Sensor Name":"WKUP"}],e=[{"Digital Sensor Number":"0","Digital Sensor Name":"WKUP"},{"Digital Sensor Number":"1","Digital Sensor Name":"DIN1"},{"Digital Sensor Number":"2","Digital Sensor Name":"DIN2"}];
 var f=[];if("VoBoXX"==a)f=c;else if("VoBoTC"==a)f=d;else if("VoBoXP"==a)f=e;else throw errorMsg=a+' -- Invalid VoBo Type. Use "VoBoXX", "VoBoTC" or "VoBoXP"',Error(errorMsg);a=f.find(g=>g["Digital Sensor Number"]==b.toString());return"undefined"==typeof a?"DigitalSensor"+b.toString():a["Digital Sensor Name"]}
 function lookupUnits(a,b){var c="";c=[{"Units Code":"1",Description:"inches of water at 20 degC (68 degF)","Abbreviated Units":"inH2O (20 degC or 68 degF)"},{"Units Code":"2",Description:"inches of mercury at 0 degC (32 degF)","Abbreviated Units":"inHg (20 degC or 68 degF)"},{"Units Code":"3",Description:"feet of water at 20 degC (68 degF)","Abbreviated Units":"ftH2O (20 degC or 68 degF)"},{"Units Code":"4",Description:"millimeters of water at 20 degC (68 degF)","Abbreviated Units":"mmH2O (20 degC or 68 degF)"},
@@ -155,15 +178,15 @@ Description:"gallons per day","Abbreviated Units":"usg/d"},{"Units Code":"236",D
 // exports had to be commented out.
 //===========================================================
 
-const payload_vb = payload.find((x) => x.variable === "payload");
-const fPort_vb = payload.find((x) => x.variable === "port" || x.variable === "fPort")?.value;
+const payload_vb = payload.find((x) => x.variable === "payload_raw" || x.variable === "payload" || x.variable === "data");
+const fPort_vb = payload.find((x) => x.variable === "port" || x.variable === "fPort" || x.variable === "fport" || x.variable === "FPort")?.value;
 
 if (payload_vb) {
     try {
         const buffer = Buffer.from(payload_vb.value, "hex")
         const decoded = toTagoFormat(buffer, fPort_vb);
-        payload = decoded;
-    } catch (error: any) {
+        payload = payload.concat(decoded);
+    } catch (error) {
         console.error(error);
         payload = [{ variable: "parse_error", value: error.message }];
     }

--- a/decoders/connector/volley-boast/vobo-tc/v1.0.0/payload.js
+++ b/decoders/connector/volley-boast/vobo-tc/v1.0.0/payload.js
@@ -12,7 +12,7 @@ function customDecoder(bytes, fport) {
             {
             variable: decoded.data.analogSensorString0,
             value: decoded.data.sensorData0,
-            units: decoded.data.engUnitsString0
+            unit: decoded.data.engUnitsString0
             }
         ];        
         tagoDecoded.push(
@@ -27,12 +27,12 @@ function customDecoder(bytes, fport) {
             {
                 variable: decoded.data.analogSensorString0,
                 value: decoded.data.sensorData0,
-                units: decoded.data.engUnitsString0
+                unit: decoded.data.engUnitsString0
             },
             {
                 variable: decoded.data.analogSensorString1,
                 value: decoded.data.sensorData1,
-                units: decoded.data.engUnitsString1
+                unit: decoded.data.engUnitsString1
             }
         ];  
         tagoDecoded.push(
@@ -56,7 +56,7 @@ function customDecoder(bytes, fport) {
         var tagoDecoded = decoded.data.ainPayloads.map((payloadObj, index) => ({
             variable: decoded.data[`analogSensorString${index}`],
             value: payloadObj.sensorData0,
-            units: decoded.data[`engUnitsString${index}`]
+            unit: decoded.data[`engUnitsString${index}`]
         }));
         tagoDecoded.push(
             { variable: "fport", value: decoded.data.fport },

--- a/decoders/connector/volley-boast/vobo-tc/v1.0.0/payload.test.ts
+++ b/decoders/connector/volley-boast/vobo-tc/v1.0.0/payload.test.ts
@@ -83,7 +83,7 @@ describe(`fPort: ${testPayloads.data[1].fport} - ${testPayloads.data[1].name}`, 
 
     test("Check if data is correct", () => {
         expect(adcTemperature.value).toBe(26.375);
-        expect(adcTemperature.units).toBe("C")
+        expect(adcTemperature.unit).toBe("C")
         expect(fport.value).toBe(31);
         expect(voboType.value).toBe('VoBoTC');
         expect(payloadType.value).toBe('One Analog Input');
@@ -110,9 +110,9 @@ describe(`fPort: ${testPayloads.data[2].fport} - ${testPayloads.data[2].name}`, 
 
     test("Check if data is correct", () => {
         expect(coldJointTemperature.value).toBe(25.515625);
-        expect(coldJointTemperature.units).toBe('C');
+        expect(coldJointTemperature.unit).toBe('C');
         expect(batteryVoltage.value).toBe(3.4612669944763184)
-        expect(batteryVoltage.units).toBe('V')
+        expect(batteryVoltage.unit).toBe('V')
         expect(fport.value).toBe(41);
         expect(voboType.value).toBe('VoBoTC');
         expect(payloadType.value).toBe('Two Analog Inputs');
@@ -243,21 +243,21 @@ describe(`fPort: ${testPayloads.data[6].fport} - ${testPayloads.data[6].name}`, 
 
     test("Check if data is correct", () => {
         expect(coldJointTemperature.value).toBe(22.203125);
-        expect(coldJointTemperature.units).toBe('C');
+        expect(coldJointTemperature.unit).toBe('C');
         expect(batteryVoltage.value).toBe(3.3329999446868896);
-        expect(batteryVoltage.units).toBe('V');
+        expect(batteryVoltage.unit).toBe('V');
         expect(tc1.value).toBe(1371.5);
-        expect(tc1.units).toBe('C');
+        expect(tc1.unit).toBe('C');
         expect(tc2.value).toBe(1371.5);
-        expect(tc2.units).toBe('C');
+        expect(tc2.unit).toBe('C');
         expect(tc3.value).toBe(1371.5);
-        expect(tc3.units).toBe('C');
+        expect(tc3.unit).toBe('C');
         expect(tc4.value).toBe(1371.5);
-        expect(tc4.units).toBe('C');
+        expect(tc4.unit).toBe('C');
         expect(tc5.value).toBe(1371.5);
-        expect(tc5.units).toBe('C');
+        expect(tc5.unit).toBe('C');
         expect(tc6.value).toBe(1371.5);
-        expect(tc6.units).toBe('C');
+        expect(tc6.unit).toBe('C');
         expect(fport.value).toBe(111);
         expect(voboType.value).toBe('VoBoTC');
         expect(payloadType.value).toBe('Analog Input Variable Length');
@@ -288,17 +288,17 @@ describe(`fPort: ${testPayloads.data[7].fport} - ${testPayloads.data[7].name}`, 
 
     test("Check if data is correct", () => {
         expect(tc7.value).toBe(1371.5);
-        expect(tc7.units).toBe('C');
+        expect(tc7.unit).toBe('C');
         expect(tc8.value).toBe(1371.5);
-        expect(tc8.units).toBe('C');
+        expect(tc8.unit).toBe('C');
         expect(tc9.value).toBe(1371.5);
-        expect(tc9.units).toBe('C');
+        expect(tc9.unit).toBe('C');
         expect(tc10.value).toBe(1371.5);
-        expect(tc10.units).toBe('C');
+        expect(tc10.unit).toBe('C');
         expect(tc11.value).toBe(1371.5);
-        expect(tc11.units).toBe('C');
+        expect(tc11.unit).toBe('C');
         expect(tc12.value).toBe(1371.5);
-        expect(tc12.units).toBe('C');
+        expect(tc12.unit).toBe('C');
         expect(fport.value).toBe(111);
         expect(voboType.value).toBe('VoBoTC');
         expect(payloadType.value).toBe('Analog Input Variable Length');

--- a/decoders/connector/volley-boast/vobo-tc/v1.0.0/payload.test.ts
+++ b/decoders/connector/volley-boast/vobo-tc/v1.0.0/payload.test.ts
@@ -25,24 +25,42 @@ describe(`fPort: ${testPayloads.data[0].fport} - ${testPayloads.data[0].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const batteryLevel = payload.find((item) => item.variable === 'batteryLevel');
+    const fatalErrorsTotal = payload.find((item) => item.variable === 'fatalErrorsTotal');
+    const rssiAvg = payload.find((item) => item.variable === 'rssiAvg');
+    const failedJoinAttemptsTotal = payload.find((item) => item.variable === 'failedJoinAttemptsTotal');
+    const configUpdateOccurred = payload.find((item) => item.variable === 'configUpdateOccurred');
+    const firmwareRevision = payload.find((item) => item.variable === 'firmwareRevision');
+    const rebootsTotal = payload.find((item) => item.variable === 'rebootsTotal');
+    const failedTransmitsTotal = payload.find((item) => item.variable === 'failedTransmitsTotal');
+    const errorEventLogsTotal = payload.find((item) => item.variable === 'errorEventLogsTotal');
+    const warningEventLogsTotal = payload.find((item) => item.variable === 'warningEventLogsTotal');
+    const infoEventLogsTotal = payload.find((item) => item.variable === 'infoEventLogsTotal');
+    const measurementPacketsTotal = payload.find((item) => item.variable === 'measurementPacketsTotal');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'batteryLevel', value: 3532 },
-            { variable: 'fatalErrorsTotal', value: 0 },
-            { variable: 'rssiAvg', value: 57 },
-            { variable: 'failedJoinAttemptsTotal', value: 0 },
-            { variable: 'configUpdateOccurred', value: 0 },
-            { variable: 'firmwareRevision', value: 0 },
-            { variable: 'rebootsTotal', value: 3 },
-            { variable: 'failedTransmitsTotal', value: 0 },
-            { variable: 'errorEventLogsTotal', value: 0 },
-            { variable: 'warningEventLogsTotal', value: 0 },
-            { variable: 'infoEventLogsTotal', value: 0 },
-            { variable: 'measurementPacketsTotal', value: 4 },
-            { variable: 'fport', value: 21 },
-            { variable: 'voboType', value: 'VoBoTC' },
-            { variable: 'payloadType', value: 'Heartbeat 2.0' }
-        ]);
+        expect(batteryLevel.value).toBe(3532);
+        expect(fatalErrorsTotal.value).toBe(0);
+        expect(rssiAvg.value).toBe(57);
+        expect(failedJoinAttemptsTotal.value).toBe(0);
+        expect(configUpdateOccurred.value).toBe(0);
+        expect(firmwareRevision.value).toBe(0);
+        expect(rebootsTotal.value).toBe(3);
+        expect(failedTransmitsTotal.value).toBe(0);
+        expect(errorEventLogsTotal.value).toBe(0);
+        expect(warningEventLogsTotal.value).toBe(0);
+        expect(infoEventLogsTotal.value).toBe(0);
+        expect(measurementPacketsTotal.value).toBe(4);
+        expect(fport.value).toBe(21);
+        expect(voboType.value).toBe('VoBoTC');
+        expect(payloadType.value).toBe('Heartbeat 2.0');
     });
 });
 
@@ -54,8 +72,21 @@ describe(`fPort: ${testPayloads.data[1].fport} - ${testPayloads.data[1].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const adcTemperature = payload.find((item) => item.variable === 'AnalogSensor15');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual({ variable: 'AnalogSensor15', value: 26.375, units: 'C' });
+        expect(adcTemperature.value).toBe(26.375);
+        expect(adcTemperature.units).toBe("C")
+        expect(fport.value).toBe(31);
+        expect(voboType.value).toBe('VoBoTC');
+        expect(payloadType.value).toBe('One Analog Input');
     });
 });
 
@@ -67,15 +98,24 @@ describe(`fPort: ${testPayloads.data[2].fport} - ${testPayloads.data[2].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const coldJointTemperature = payload.find((item) => item.variable === 'Cold Joint Temperature');
+    const batteryVoltage = payload.find((item) => item.variable === 'Battery Voltage');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'Cold Joint Temperature', value: 25.515625, units: 'C' },
-            {
-                variable: 'Battery Voltage',
-                value: 3.4612669944763184,
-                units: 'V'
-            }
-        ]);
+        expect(coldJointTemperature.value).toBe(25.515625);
+        expect(coldJointTemperature.units).toBe('C');
+        expect(batteryVoltage.value).toBe(3.4612669944763184)
+        expect(batteryVoltage.units).toBe('V')
+        expect(fport.value).toBe(41);
+        expect(voboType.value).toBe('VoBoTC');
+        expect(payloadType.value).toBe('Two Analog Inputs');
     });
 });
 
@@ -87,13 +127,20 @@ describe(`fPort: ${testPayloads.data[3].fport} - ${testPayloads.data[3].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const wkup = payload.find((item) => item.variable === 'WKUP');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'WKUP', value: 0 },
-            { variable: 'fport', value: 51 },
-            { variable: 'voboType', value: 'VoBoTC' },
-            { variable: 'payloadType', value: 'Digital Inputs' }
-        ]);
+        expect(wkup.value).toBe(0);
+        expect(fport.value).toBe(51);
+        expect(voboType.value).toBe('VoBoTC');
+        expect(payloadType.value).toBe('Digital Inputs');
     });
 });
 
@@ -105,15 +152,24 @@ describe(`fPort: ${testPayloads.data[4].fport} - ${testPayloads.data[4].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const eventTimestamp = payload.find((item) => item.variable === 'eventTimestamp');
+    const eventCode = payload.find((item) => item.variable === 'eventCode');
+    const metadata = payload.find((item) => item.variable === 'metadata');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'eventTimestamp', value: 1689471305 },
-            { variable: 'eventCode', value: 32774 },
-            { variable: 'metadata', value: [0, 0, 0, 0, 0] },
-            { variable: 'fport', value: 61 },
-            { variable: 'voboType', value: 'VoBoTC' },
-            { variable: 'payloadType', value: 'Event Log' }
-        ]);
+        expect(eventTimestamp.value).toBe(1689471305);
+        expect(eventCode.value).toBe(32774);
+        expect(metadata.value).toStrictEqual([0, 0, 0, 0, 0]);
+        expect(fport.value).toBe(61);
+        expect(voboType.value).toBe('VoBoTC');
+        expect(payloadType.value).toBe('Event Log');
     });
 });
 
@@ -125,22 +181,38 @@ describe(`fPort: ${testPayloads.data[5].fport} - ${testPayloads.data[5].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const subgroupID = payload.find((item) => item.variable === 'subgroupID');
+    const sequenceNumber = payload.find((item) => item.variable === 'sequenceNumber');
+    const gain11 = payload.find((item) => item.variable === 'gain11');
+    const reserved1 = payload.find((item) => item.variable === 'reserved1');
+    const offset11 = payload.find((item) => item.variable === 'offset11');
+    const reserved2 = payload.find((item) => item.variable === 'reserved2');
+    const gain12 = payload.find((item) => item.variable === 'gain12');
+    const reserved3 = payload.find((item) => item.variable === 'reserved3');
+    const offset12 = payload.find((item) => item.variable === 'offset12');
+    const reserved4 = payload.find((item) => item.variable === 'reserved4');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'subgroupID', value: 5 },
-            { variable: 'sequenceNumber', value: 5 },
-            { variable: 'gain11', value: 1 },
-            { variable: 'reserved1', value: 0 },
-            { variable: 'offset11', value: 0 },
-            { variable: 'reserved2', value: 0 },
-            { variable: 'gain12', value: 1 },
-            { variable: 'reserved3', value: 0 },
-            { variable: 'offset12', value: 0 },
-            { variable: 'reserved4', value: 0 },
-            { variable: 'fport', value: 71 },
-            { variable: 'voboType', value: 'VoBoTC' },
-            { variable: 'payloadType', value: 'Configuration' }
-        ]);
+        expect(subgroupID.value).toBe(5);
+        expect(sequenceNumber.value).toBe(5);
+        expect(gain11.value).toBe(1);
+        expect(reserved1.value).toBe(0);
+        expect(offset11.value).toBe(0);
+        expect(reserved2.value).toBe(0);
+        expect(gain12.value).toBe(1);
+        expect(reserved3.value).toBe(0);
+        expect(offset12.value).toBe(0);
+        expect(reserved4.value).toBe(0);
+        expect(fport.value).toBe(71);
+        expect(voboType.value).toBe('VoBoTC');
+        expect(payloadType.value).toBe('Configuration');
     });
 });
 
@@ -153,21 +225,42 @@ describe(`fPort: ${testPayloads.data[6].fport} - ${testPayloads.data[6].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const coldJointTemperature = payload.find((item) => item.variable === 'Cold Joint Temperature');
+    const batteryVoltage = payload.find((item) => item.variable === 'Battery Voltage');
+    const tc1 = payload.find((item) => item.variable === 'TC1');
+    const tc2 = payload.find((item) => item.variable === 'TC2');
+    const tc3 = payload.find((item) => item.variable === 'TC3');
+    const tc4 = payload.find((item) => item.variable === 'TC4');
+    const tc5 = payload.find((item) => item.variable === 'TC5');
+    const tc6 = payload.find((item) => item.variable === 'TC6');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'Cold Joint Temperature', value: 22.203125, units: 'C' },
-            {
-                variable: 'Battery Voltage',
-                value: 3.3329999446868896,
-                units: 'V'
-            },
-            { variable: 'TC1', value: 1371.5, units: 'C' },
-            { variable: 'TC2', value: 1371.5, units: 'C' },
-            { variable: 'TC3', value: 1371.5, units: 'C' },
-            { variable: 'TC4', value: 1371.5, units: 'C' },
-            { variable: 'TC5', value: 1371.5, units: 'C' },
-            { variable: 'TC6', value: 1371.5, units: 'C' }
-        ]);
+        expect(coldJointTemperature.value).toBe(22.203125);
+        expect(coldJointTemperature.units).toBe('C');
+        expect(batteryVoltage.value).toBe(3.3329999446868896);
+        expect(batteryVoltage.units).toBe('V');
+        expect(tc1.value).toBe(1371.5);
+        expect(tc1.units).toBe('C');
+        expect(tc2.value).toBe(1371.5);
+        expect(tc2.units).toBe('C');
+        expect(tc3.value).toBe(1371.5);
+        expect(tc3.units).toBe('C');
+        expect(tc4.value).toBe(1371.5);
+        expect(tc4.units).toBe('C');
+        expect(tc5.value).toBe(1371.5);
+        expect(tc5.units).toBe('C');
+        expect(tc6.value).toBe(1371.5);
+        expect(tc6.units).toBe('C');
+        expect(fport.value).toBe(111);
+        expect(voboType.value).toBe('VoBoTC');
+        expect(payloadType.value).toBe('Analog Input Variable Length');
     });
 });
 
@@ -179,15 +272,36 @@ describe(`fPort: ${testPayloads.data[7].fport} - ${testPayloads.data[7].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const tc7 = payload.find((item) => item.variable === 'TC7');
+    const tc8 = payload.find((item) => item.variable === 'TC8');
+    const tc9 = payload.find((item) => item.variable === 'TC9');
+    const tc10 = payload.find((item) => item.variable === 'TC10');
+    const tc11 = payload.find((item) => item.variable === 'TC11');
+    const tc12 = payload.find((item) => item.variable === 'TC12');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'TC7', value: 1371.5, units: 'C' },
-            { variable: 'TC8', value: 1371.5, units: 'C' },
-            { variable: 'TC9', value: 1371.5, units: 'C' },
-            { variable: 'TC10', value: 1371.5, units: 'C' },
-            { variable: 'TC11', value: 1371.5, units: 'C' },
-            { variable: 'TC12', value: 1371.5, units: 'C' }
-        ]);
+        expect(tc7.value).toBe(1371.5);
+        expect(tc7.units).toBe('C');
+        expect(tc8.value).toBe(1371.5);
+        expect(tc8.units).toBe('C');
+        expect(tc9.value).toBe(1371.5);
+        expect(tc9.units).toBe('C');
+        expect(tc10.value).toBe(1371.5);
+        expect(tc10.units).toBe('C');
+        expect(tc11.value).toBe(1371.5);
+        expect(tc11.units).toBe('C');
+        expect(tc12.value).toBe(1371.5);
+        expect(tc12.units).toBe('C');
+        expect(fport.value).toBe(111);
+        expect(voboType.value).toBe('VoBoTC');
+        expect(payloadType.value).toBe('Analog Input Variable Length');
     });
 });
 

--- a/decoders/connector/volley-boast/vobo-xp/v1.0.0/payload.js
+++ b/decoders/connector/volley-boast/vobo-xp/v1.0.0/payload.js
@@ -8,11 +8,18 @@ function customDecoder(bytes, fport) {
     //=======================================================
     // Insert your customization here
     if (fport == 32) {
-        var tagoDecoded = {
-            variable: decoded.data.analogSensorString0,
-            value: decoded.data.sensorData0,
-            units: decoded.data.engUnitsString0
-        }
+        var tagoDecoded = [
+            {
+                variable: decoded.data.analogSensorString0,
+                value: decoded.data.sensorData0,
+                units: decoded.data.engUnitsString0
+            }
+        ];
+        tagoDecoded.push(
+            { variable: "fport", value: decoded.data.fport },
+            { variable: "voboType", value: decoded.data.voboType },
+            { variable: "payloadType", value: decoded.data.payloadType }
+        );
     }
     else if (fport == 42) {
         var tagoDecoded = [
@@ -26,14 +33,18 @@ function customDecoder(bytes, fport) {
                 value: decoded.data.sensorData1,
                 units: decoded.data.engUnitsString1
             }
-        ]
+        ];
+        tagoDecoded.push(
+            { variable: "fport", value: decoded.data.fport },
+            { variable: "voboType", value: decoded.data.voboType },
+            { variable: "payloadType", value: decoded.data.payloadType }
+        );
     }
     else if (fport == 52) {
         var tagoDecoded = decoded.data.digitalSensorStrings.map((sensor, index) => ({
             variable: sensor,
             value: decoded.data.digitalSensorData[index]
         }));
-
         tagoDecoded.push(
             { variable: "fport", value: decoded.data.fport },
             { variable: "voboType", value: decoded.data.voboType },
@@ -46,12 +57,22 @@ function customDecoder(bytes, fport) {
             value: payloadObj.sensorData0,
             units: decoded.data[`engUnitsString${index}`]
         }));
+        tagoDecoded.push(
+            { variable: "fport", value: decoded.data.fport },
+            { variable: "voboType", value: decoded.data.voboType },
+            { variable: "payloadType", value: decoded.data.payloadType }
+        );
     }
     else if (fport == 122) {
         var tagoDecoded = Object.entries(decoded.data.modbusSlots).map(([key, value]) => ({
             variable: key,
             value: value
         }));
+        tagoDecoded.push(
+            { variable: "fport", value: decoded.data.fport },
+            { variable: "voboType", value: decoded.data.voboType },
+            { variable: "payloadType", value: decoded.data.payloadType }
+        );
     }
     else {
         var tagoDecoded = Object.entries(decoded.data).map(([key, value]) => ({
@@ -63,13 +84,13 @@ function customDecoder(bytes, fport) {
     return tagoDecoded;
 }
 
-const DECODER_MAJOR_VERSION=2,DECODER_MINOR_VERSION=1,DECODER_PATCH_VERSION=1;function decodeUplink(a){return Decoder(a.bytes,a.fPort)}
-function Decoder(a,b){var c={},d=[];1==b?c=parseStandardPayload(a):2<=b&&9>=b?c=parseModbusStandardPayload(a,b):10==b?c=parseHeartbeat1p0Payload(a):20<=b&&29>=b?c=parseHeartbeat2p0Payload(a):30<=b&&39>=b?c=parseOneAnalogSensorPayload(a):40<=b&&49>=b?c=parseTwoAnalogSensorsPayload(a):50<=b&&59>=b?c=parseDigitalSensorsPayload(a):60<=b&&69>=b?c=parseEventLogPayload(a):70<=b&&79>=b?c=parseConfigurationPayload(a,b):100<=b&&109>=b?c=parseModbusGenericPayload(a,b):110<=b&&119>=b?c=parseAnalogInputVariableLengthPayload(a,
-b):120<=b&&129>=b?c=parseModbusStandardVariableLengthPayload(a,b):d.push("unknown FPort");a=addVoboMetadata(c,b);a.warnings=[];a.errors=d;return a}
+const DECODER_MAJOR_VERSION=2,DECODER_MINOR_VERSION=2,DECODER_PATCH_VERSION=0;function decodeUplink(a){return Decoder(a.bytes,a.fPort)}
+function Decoder(a,b){var c={},d=[];1==b?c=parseStandardPayload(a):2<=b&&9>=b?c=parseModbusStandardPayload(a,b):10==b?c=parseHeartbeat1p0Payload(a):20<=b&&29>=b?c=parseHeartbeat2p0Payload(a):30<=b&&39>=b?c=parseOneAnalogSensorPayload(a):40<=b&&49>=b?c=parseTwoAnalogSensorsPayload(a):50<=b&&59>=b?c=parseDigitalSensorsPayload(a):60<=b&&69>=b?c=parseEventLogPayload(a):70<=b&&79>=b?c=parseConfigurationPayload(a,b):80<=b&&89>=b?c=parseEventLogPayload(a):100<=b&&109>=b?c=parseModbusGenericPayload(a,b):
+110<=b&&119>=b?c=parseAnalogInputVariableLengthPayload(a,b):120<=b&&129>=b?c=parseModbusStandardVariableLengthPayload(a,b):d.push("unknown FPort");a=addVoboMetadata(c,b);a.warnings=[];a.errors=d;return a}
 function addVoboMetadata(a,b){var c={};c.data=a;var d=a="",e=b%10;0==e||1<=b&&10>b?a="VoBoXX":1==e?a="VoBoTC":2==e&&(a="VoBoXP");if(1==b)d="Standard";else if(2<=b&&9>=b)d="Modbus Standard";else if(10==b)d="Heartbeat 1.0";else if(20<=b&&29>=b)d="Heartbeat 2.0";else if(30<=b&&39>=b)d="One Analog Input",c.data.analogSensorString0=lookupAnalogSensorName(a,c.data.sensorNum0),c.data.engUnitsString0=lookupUnits(1,c.data.sensorUnits0);else if(40<=b&&49>=b)d="Two Analog Inputs",c.data.analogSensorString0=
 lookupAnalogSensorName(a,c.data.sensorNum0),c.data.engUnitsString0=lookupUnits(1,c.data.sensorUnits0),c.data.analogSensorString1=lookupAnalogSensorName(a,c.data.sensorNum1),c.data.engUnitsString1=lookupUnits(1,c.data.sensorUnits1);else if(50<=b&&59>=b)for(d="Digital Inputs",c.data.digitalSensorStrings=[],c.data.digitalSensorData=[],e=0;16>e;e++)1==(c.data.sensorValid0>>e&1)&&(c.data.digitalSensorStrings.push(lookupDigitalSensorName(a,e)),c.data.digitalSensorData.push(c.data.sensorData0>>e&1));else if(60<=
-b&&69>=b)d="Event Log";else if(70<=b&&79>=b)d="Configuration";else if(100<=b&&109>=b)d="Modbus Generic";else if(110<=b&&119>=b)for(d="Analog Input Variable Length",e=0;e<c.data.numOfAinPayloads;e++)c.data["analogSensorString"+e]=lookupAnalogSensorName(a,c.data.ainPayloads[e].sensorNum0),c.data["engUnitsString"+e]=lookupUnits(1,c.data.ainPayloads[e].sensorUnits0);else 120<=b&&129>=b&&(d="Modbus Standard Variable Length");c.data.fport=b;c.data.voboType=a;c.data.payloadType=d;return c}
-function parseStandardPayload(a){var b={};b.DIN1=a[0]&1;b.DIN2=a[0]>>1&1;b.DIN3=a[0]>>2&1;b.WKUP=a[0]>>3&1;b.ADC1=(a[0]&240)>>4|a[1]<<4;b.ADC2=(a[3]&15)<<8|a[2];b.ADC3=(a[3]&240)>>4|a[4]<<4;b.Battery=4*((a[6]&15)<<8|a[5]);b.Temperature=0==(a[7]>>7&1)?.125*((a[6]&240)>>4|a[7]<<4):-.125*(4096-((a[6]&240)>>4|a[7]<<4));b.Modbus0=a[9]<<8|a[8];return b}
+b&&69>=b)d="Event Log";else if(70<=b&&79>=b)d="Configuration";else if(80<=b&&89>=b)d="Notification";else if(100<=b&&109>=b)d="Modbus Generic";else if(110<=b&&119>=b)for(d="Analog Input Variable Length",e=0;e<c.data.numOfAinPayloads;e++)c.data["analogSensorString"+e]=lookupAnalogSensorName(a,c.data.ainPayloads[e].sensorNum0),c.data["engUnitsString"+e]=lookupUnits(1,c.data.ainPayloads[e].sensorUnits0);else 120<=b&&129>=b&&(d="Modbus Standard Variable Length");c.data.fport=b;c.data.voboType=a;c.data.payloadType=
+d;return c}function parseStandardPayload(a){var b={};b.DIN1=a[0]&1;b.DIN2=a[0]>>1&1;b.DIN3=a[0]>>2&1;b.WKUP=a[0]>>3&1;b.ADC1=(a[0]&240)>>4|a[1]<<4;b.ADC2=(a[3]&15)<<8|a[2];b.ADC3=(a[3]&240)>>4|a[4]<<4;b.Battery=4*((a[6]&15)<<8|a[5]);b.Temperature=0==(a[7]>>7&1)?.125*((a[6]&240)>>4|a[7]<<4):-.125*(4096-((a[6]&240)>>4|a[7]<<4));b.Modbus0=a[9]<<8|a[8];return b}
 function parseModbusStandardPayload(a,b){b=5*(b-1)-4;var c={};c["Modbus"+b++]=a[1]<<8|a[0];c["Modbus"+b++]=a[3]<<8|a[2];c["Modbus"+b++]=a[5]<<8|a[4];c["Modbus"+b++]=a[7]<<8|a[6];c["Modbus"+b]=a[9]<<8|a[8];return c}
 function parseHeartbeat1p0Payload(a){var b={};b.batteryLevelMV=4*((a[1]&15)<<8|a[0]);b.fwVersionMajor=a[2]&15|(a[1]&240)>>4;b.fwVersionMinor=a[3]&15|(a[2]&240)>>4;b.fwVersionPatch=a[4]&15|(a[3]&240)>>4;b.fwVersionCustom=(a[4]&240)>>4;b.recSignalLevels=-1*a[5];b.analogVoltageConfig=a[6]&31;b.analogPowerTimeConfig=parseFloat((((a[7]&31)<<3|(a[6]&224)>>5)/10).toFixed(1));b.failedTransmissionBeforeRejoinConfig=(a[8]&1)<<3|(a[7]&224)>>5;b.cycleThroughFSB=(a[8]&2)>>1;b.ackEnable=(a[8]&4)>>2;b.ackFreq=(a[8]&
 120)>>3;b.ackReq=(a[9]&7)<<1|(a[8]&128)>>7;b.batteryLevelThreshold=4*((a[10]&127)<<5|(a[9]&248)>>3);return b}
@@ -77,8 +98,8 @@ function parseHeartbeat2p0Payload(a){var b={};b.batteryLevel=(a[1]&15)<<8|a[0];b
 function bytesToFloat32(a){var b=new ArrayBuffer(4),c=new Uint8Array(b);c[0]=a[0];c[1]=a[1];c[2]=a[2];c[3]=a[3];return(new DataView(b)).getFloat32(0,!1)}function parseOneAnalogSensorPayload(a){var b={};b.sensorNum0=a[0];b.sensorUnits0=a[1];b.sensorData0=bytesToFloat32(a.slice(2,6));return b}
 function parseTwoAnalogSensorsPayload(a){var b={};b.sensorNum0=(a[0]&240)>>4;b.sensorUnits0=a[1];b.sensorData0=bytesToFloat32(a.slice(2,6));b.sensorNum1=a[0]&15;b.sensorUnits1=a[6];b.sensorData1=bytesToFloat32(a.slice(7,11));return b}function parseDigitalSensorsPayload(a){var b={};b.sensorValid0=a[1]<<8|a[0];b.sensorData0=a[3]<<8|a[2];return b}
 function parseEventLogPayload(a){var b={};b.eventTimestamp=a[0]+a[1]*Math.pow(2,8)+a[2]*Math.pow(2,16)+a[3]*Math.pow(2,24);b.eventCode=a[4]+a[5]*Math.pow(2,8);b.metadata=Array.prototype.slice.call(a.slice(6,11),0);return b}
-function parseVoboLibGeneralConfigurationPayload(a){var b={};b.subgroupID=a[0]&15;b.sequenceNumber=(a[0]&240)>>4;0==b.sequenceNumber&&(b.transRejoin=a[1]&15,b.ackFrequency=(a[1]&240)>>4,b.lowBattery=parseFloat(((a[2]&15)/10+2.5).toFixed(1)),b.reserved1=(a[2]&16)>>4,b.heartbeatAckEnable=!!((a[2]&32)>>5),b.operationMode=(a[2]&64)>>6,b.cycleSubBands=!!((a[2]&128)>>7),b.ackRetries=a[3]&7,b.reservedLL=(a[3]&56)>>3,b.ackEnable=!!((a[3]&64)>>6),b.heartbeatEnable=!!((a[3]&128)>>7),b.cycleTime=(a[6]&3)<<16|
-a[5]<<8|a[4],b.backOffReset=(a[6]&252)>>2,b.reservedRD=a[7]&63,b.reserved2=(a[7]&192)>>6,b.resendAttempts=a[8]&15,b.freqSubBand=(a[8]&240)>>4);if(1==b.sequenceNumber){b.timeSyncInterval=a[1];b.joinEUI="";for(let c=9;2<=c;c--)b.joinEUI+=a[c].toString(16).toUpperCase().padStart(2,0),2!=c&&(b.joinEUI+="-");b.joinNonceResetEnable=!!(a[10]&1);b.timeSyncWakeupEnable=!!((a[10]&2)>>1);b.reserved1=(a[10]&252)>>2}return b}
+function parseVoboLibGeneralConfigurationPayload(a,b){var c={};c.subgroupID=a[0]&15;c.sequenceNumber=(a[0]&240)>>4;0==c.sequenceNumber&&(c.transRejoin=a[1]&15,c.ackFrequency=(a[1]&240)>>4,70==b||71==b?c.lowBattery=parseFloat(((a[2]&15)/10+2.5).toFixed(1)):72==b&&(c.lowVoltThreshold=parseFloat(((a[2]&15)/10+2.5).toFixed(1))),c.reserved1=(a[2]&16)>>4,c.heartbeatAckEnable=!!((a[2]&32)>>5),c.operationMode=(a[2]&64)>>6,c.cycleSubBands=!!((a[2]&128)>>7),c.ackRetries=a[3]&7,c.reservedLL=(a[3]&56)>>3,c.ackEnable=
+!!((a[3]&64)>>6),c.heartbeatEnable=!!((a[3]&128)>>7),c.cycleTime=(a[6]&3)<<16|a[5]<<8|a[4],c.backOffReset=(a[6]&252)>>2,c.reservedRD=a[7]&63,c.reserved2=(a[7]&192)>>6,c.resendAttempts=a[8]&15,c.freqSubBand=(a[8]&240)>>4);if(1==c.sequenceNumber){c.timeSyncInterval=a[1];c.joinEUI="";for(b=9;2<=b;b--)c.joinEUI+=a[b].toString(16).toUpperCase().padStart(2,0),2!=b&&(c.joinEUI+="-");c.joinNonceResetEnable=!!(a[10]&1);c.timeSyncWakeupEnable=!!((a[10]&2)>>1);c.reserved1=(a[10]&252)>>2}return c}
 function parseVoboLibVoboSyncConfigurationPayload(a){var b={};b.subgroupID=a[0]&15;b.sequenceNumber=(a[0]&240)>>4;0==b.sequenceNumber&&(b.vbsNodeNumber=a[2]<<8|a[1],b.vbsTimeReference=a.slice(3,7).readUInt32LE(),b.reservedVCPDS=a[7]&15,b.reservedVMPDS=(a[7]&240)>>4,b.reservedVUDS=a[8]&15,b.reserved1=(a[8]&48)>>4,b.reservedVSAE=!!((a[8]&64)>>6),b.vbsEnable=!!((a[8]&128)>>7),b.reserved3=a[9]&63,b.reserved2=(a[9]&192)>>6);1==b.sequenceNumber&&(b.vbsMeasurementDelaySec=a[1]&127,b.reserved1=(a[1]&128)>>
 7,b.vbsUplinkDelaySec=a[2]&127,b.reserved2=(a[2]&128)>>7);return b}
 function parseVoboXXGeneralConfigurationPayload(a){var b={};b.subgroupID=a[0]&15;b.sequenceNumber=(a[0]&240)>>4;b.analogVoltage=parseFloat((a[1]/10).toFixed(1));b.powerTime=parseFloat((a[2]/10).toFixed(1));b.mbEnable=!!(a[3]&1);b.engUnitsEnable=!!(a[3]>>1&1);b.din1TransmitEnable=!!(a[3]>>2&1);b.din2TransmitEnable=!!(a[3]>>3&1);b.din3TransmitEnable=!!(a[3]>>4&1);b.wkupTransmitEnable=!!(a[3]>>5&1);b.ain1TransmitEnable=!!(a[3]>>6&1);b.ain2TransmitEnable=!!(a[3]>>7&1);b.ain3TransmitEnable=!!(a[4]&1);
@@ -110,8 +131,14 @@ function parseVoboTCCalibrationConfigurationPayload(a){var b={};b.subgroupID=a[0
 b.reserved2=(a[4]&128)>>7,b.gain6=parseFloat((((a[6]&7)<<8|a[5])/1E3).toFixed(3)),b.reserved3=(a[6]&248)>>3,b.offset6=parseFloat((((a[8]&127)<<8|a[7])/1E3-10).toFixed(3)),b.reserved4=(a[8]&128)>>7);3==b.sequenceNumber&&(b.gain7=parseFloat((((a[2]&7)<<8|a[1])/1E3).toFixed(3)),b.reserved1=(a[2]&248)>>3,b.offset7=parseFloat((((a[4]&127)<<8|a[3])/1E3-10).toFixed(3)),b.reserved2=(a[4]&128)>>7,b.gain8=parseFloat((((a[6]&7)<<8|a[5])/1E3).toFixed(3)),b.reserved3=(a[6]&248)>>3,b.offset8=parseFloat((((a[8]&
 127)<<8|a[7])/1E3-10).toFixed(3)),b.reserved4=(a[8]&128)>>7);4==b.sequenceNumber&&(b.gain9=parseFloat((((a[2]&7)<<8|a[1])/1E3).toFixed(3)),b.reserved1=(a[2]&248)>>3,b.offset9=parseFloat((((a[4]&127)<<8|a[3])/1E3-10).toFixed(3)),b.reserved2=(a[4]&128)>>7,b.gain10=parseFloat((((a[6]&7)<<8|a[5])/1E3).toFixed(3)),b.reserved3=(a[6]&248)>>3,b.offset10=parseFloat((((a[8]&127)<<8|a[7])/1E3-10).toFixed(3)),b.reserved4=(a[8]&128)>>7);5==b.sequenceNumber&&(b.gain11=parseFloat((((a[2]&7)<<8|a[1])/1E3).toFixed(3)),
 b.reserved1=(a[2]&248)>>3,b.offset11=parseFloat((((a[4]&127)<<8|a[3])/1E3-10).toFixed(3)),b.reserved2=(a[4]&128)>>7,b.gain12=parseFloat((((a[6]&7)<<8|a[5])/1E3).toFixed(3)),b.reserved3=(a[6]&248)>>3,b.offset12=parseFloat((((a[8]&127)<<8|a[7])/1E3-10).toFixed(3)),b.reserved4=(a[8]&128)>>7);return b}
-function parseConfigurationPayload(a,b){var c={},d=a[0]&15;0==d?c=parseVoboLibGeneralConfigurationPayload(a):1==d?c=parseVoboLibVoboSyncConfigurationPayload(a):70==b&&4==d?c=parseVoboXXGeneralConfigurationPayload(a):70==b&&5==d?c=parseVoboXXModbusGeneralConfigurationPayload(a):70!=b||6!=d&&7!=d?70!=b||8!=d&&9!=d&&10!=d?70==b&&11==d?c=parseVoboXXModbusPayloadsSlotsConfigurationPayload(a):70==b&&12==d?c=parseVoboXXEngineeringUnitsConfigurationPayload(a):71==b&&4==d?c=parseVoboTCGeneralConfigurationPayload(a):
-71==b&&5==d&&(c=parseVoboTCCalibrationConfigurationPayload(a)):c=parseVoboXXModbusGroupsConfigurationPayload(a):c=parseVoboXXModbusGroupsEnableConfigurationPayload(a);return c}
+function parseVoboXPGeneralConfigurationPayload(a){var b={};b.subgroupID=a[0]&15;b.sequenceNumber=(a[0]&240)>>4;0==b.sequenceNumber&&(b.analogVoltage=parseFloat((a[1]/10).toFixed(1)),b.powerTime=parseFloat((a[2]/10).toFixed(1)),b.mbEnable=!!(a[3]&1),b.reserved1=a[3]>>1&127,b.reserved2=a[4]&7,b.mbTransmitEnable=!!(a[4]>>3&1),b.ainPayloadType=a[4]>>4&1,b.reservedMAWE=!!(a[4]>>5&1),b.reservedMADE=!!(a[4]>>6&1),b.reservedMAME=!!(a[4]>>7&1),b.reservedDTC=a[6]<<8|a[5]);1==b.sequenceNumber&&(b.stateRLY1=
+a[1]&1,b.stateRLY2=a[1]>>1&1,b.stateRLY3=a[1]>>2&1,b.stateRLY4=a[1]>>3&1,b.reserved1=a[1]>>4&15,b.lorawanClass=a[2]&1,b.contMeasEnable=!!(a[2]>>1&1),b.reservedARDE=!!(a[2]>>2&1),b.pFailWarnEnable=!!(a[2]>>3&1),b.pcntDin1Enable=!!(a[2]>>4&1),b.pcntDin2Enable=!!(a[2]>>5&1),b.reserved2=a[2]>>6&3,b.pcntDin1Type=a[3]&3,b.pcntDin2Type=a[3]>>2&3,b.reserved3=a[3]>>4&15,b.pcntPeriod=a[4]&63,b.reserved4=a[4]>>6&3,b.contMeasCycleTime=a[5]&63,b.reserved5=a[5]>>6&3,b.pFailThreshold=parseFloat((a[6]/10).toFixed(1)),
+b.serialPHY=a[7]&1,b.reserved6=a[7]>>1&7,b.serialProtoRS485=a[7]>>4&1,b.reserved7=a[7]>>5&1,b.serialProtoRS232=a[7]>>6&1,b.reserved8=a[7]>>7&1);return b}
+function parseVoboXPTransmitEncodingConfigurationPayload(a){var b={};b.subgroupID=a[0]&15;b.sequenceNumber=(a[0]&240)>>4;b.txAin1=a[1]&15;b.txAin2=a[1]>>4&15;b.txAin3=a[2]&15;b.txDin1=a[2]>>4&15;b.txDin2=a[3]&15;b.txPcntDin1=a[3]>>4&15;b.txPcntDin2=a[4]&15;b.txWKUP=a[4]>>4&15;b.txTemp=a[5]&15;b.txVoltRLY1=a[5]>>4&15;b.txVoltRLY2=a[6]&15;b.txVoltRLY3=a[6]>>4&15;b.txVoltRLY4=a[7]&15;b.txVoltVIN=a[7]>>4&15;b.txVolt3V3=a[8]&15;b.txVoltVPP=a[8]>>4&15;b.txContMeasPeriod=a[9]&15;b.txContMeasCnt=a[9]>>4&
+1;b.reserved1=a[9]>>5&7;return b}function parseVoboXPRelayPulseConfigurationPayload(a){var b={};b.subgroupID=a[0]&15;b.sequenceNumber=(a[0]&240)>>4;0==b.sequenceNumber?(b.pulseDelayRLY1=a[2]<<8|a[1],b.pulsePeriodRLY1=a[4]<<8|a[3],b.pulseDelayRLY2=a[6]<<8|a[5],b.pulsePeriodRLY2=a[8]<<8|a[7]):1==b.sequenceNumber&&(b.pulseDelayRLY3=a[2]<<8|a[1],b.pulsePeriodRLY3=a[4]<<8|a[3],b.pulseDelayRLY4=a[6]<<8|a[5],b.pulsePeriodRLY4=a[8]<<8|a[7]);return b}
+function parseConfigurationPayload(a,b){var c={},d=a[0]&15;0==d?c=parseVoboLibGeneralConfigurationPayload(a,b):1==d?c=parseVoboLibVoboSyncConfigurationPayload(a):70==b&&4==d?c=parseVoboXXGeneralConfigurationPayload(a):70==b&&5==d?c=parseVoboXXModbusGeneralConfigurationPayload(a):70!=b||6!=d&&7!=d?70!=b||8!=d&&9!=d&&10!=d?70==b&&11==d?c=parseVoboXXModbusPayloadsSlotsConfigurationPayload(a):70==b&&12==d?c=parseVoboXXEngineeringUnitsConfigurationPayload(a):71==b&&4==d?c=parseVoboTCGeneralConfigurationPayload(a):
+71==b&&5==d?c=parseVoboTCCalibrationConfigurationPayload(a):72==b&&4==d?c=parseVoboXPGeneralConfigurationPayload(a):72==b&&5==d?c=parseVoboXXModbusGeneralConfigurationPayload(a):72!=b||6!=d&&7!=d?72!=b||8!=d&&9!=d&&10!=d?72==b&&11==d?c=parseVoboXXModbusPayloadsSlotsConfigurationPayload(a):72==b&&12==d?c=parseVoboXXEngineeringUnitsConfigurationPayload(a):72==b&&13==d?c=parseVoboXPTransmitEncodingConfigurationPayload(a):72==b&&14==d&&(c=parseVoboXPRelayPulseConfigurationPayload(a)):c=parseVoboXXModbusGroupsConfigurationPayload(a):
+c=parseVoboXXModbusGroupsEnableConfigurationPayload(a):c=parseVoboXXModbusGroupsConfigurationPayload(a):c=parseVoboXXModbusGroupsEnableConfigurationPayload(a);return c}
 function parseModbusGenericPayload(a,b){b={};for(var c=a.length,d=0;d<c-1;){var e=a[d]&63;if(0<e){var f=a[d]>>6&3;d++;if(0==f){var g=a[d+1]<<8|a[d];b["group"+e+"register1"]=g;d+=2}else if(1==f)b["group"+e+"register1"]=a[d+1]<<8|a[d],b["group"+e+"register2"]=a[d+3]<<8|a[d+2],d+=4;else if(2==f){f=[];var h=a[d]&127;d++;for(var k=0;k<h;k++)g=a[d+1]<<8|a[d],b["group"+e+"register"+(k+1)]=g,f.push(g),d+=2}else if(3==f){f=[];h=a[d]&127;d++;k=a[d]&127;d++;h-=k;g=Math.floor((c-d)/2);h>g&&(h=g);for(let l=0;l<
 h;l++)g=a[d+1]<<8|a[d],b["group"+e+"register"+(k+l+1)]=g,f.push(g),d+=2}}else break}return b}function parseAnalogInputVariableLengthPayload(a,b){b={};for(var c=[],d=a.length,e=0;e<d;){var f=a.slice(e,e+6);f=parseOneAnalogSensorPayload(f);c.push(f);e+=6}b.ainPayloads=c;b.numOfAinPayloads=c.length;return b}
 function parseModbusStandardVariableLengthPayload(a,b){b={};for(var c={},d=a.length,e=a[d-1],f=0;f<d-1;)c["Modbus"+(e+f/2)]=a[f+1]<<8|a[f],f+=2;b.modbusSlots=c;b.firstSlotNum=e;b.numModbusSlots=(d-1)/2;return b}
@@ -119,8 +146,8 @@ function lookupAnalogSensorName(a,b){var c=[{"Analog Sensor Number":"0","Analog 
 "Analog Sensor Name":"TC2"},{"Analog Sensor Number":"3","Analog Sensor Name":"TC3"},{"Analog Sensor Number":"4","Analog Sensor Name":"TC4"},{"Analog Sensor Number":"5","Analog Sensor Name":"TC5"},{"Analog Sensor Number":"6","Analog Sensor Name":"TC6"},{"Analog Sensor Number":"7","Analog Sensor Name":"TC7"},{"Analog Sensor Number":"8","Analog Sensor Name":"TC8"},{"Analog Sensor Number":"9","Analog Sensor Name":"TC9"},{"Analog Sensor Number":"10","Analog Sensor Name":"TC10"},{"Analog Sensor Number":"11",
 "Analog Sensor Name":"TC11"},{"Analog Sensor Number":"12","Analog Sensor Name":"TC12"},{"Analog Sensor Number":"13","Analog Sensor Name":"Cold Joint Temperature"}],e=[{"Analog Sensor Number":"0","Analog Sensor Name":"3.3V Supply Voltage"},{"Analog Sensor Number":"1","Analog Sensor Name":"AIN1"},{"Analog Sensor Number":"2","Analog Sensor Name":"AIN2"},{"Analog Sensor Number":"3","Analog Sensor Name":"AIN3"},{"Analog Sensor Number":"4","Analog Sensor Name":"DIN1"},{"Analog Sensor Number":"5","Analog Sensor Name":"DIN1 Pulse Count"},
 {"Analog Sensor Number":"6","Analog Sensor Name":"DIN2"},{"Analog Sensor Number":"7","Analog Sensor Name":"DIN2 Pulse Count"},{"Analog Sensor Number":"8","Analog Sensor Name":"RLY1 Voltage"},{"Analog Sensor Number":"9","Analog Sensor Name":"RLY2 Voltage"},{"Analog Sensor Number":"10","Analog Sensor Name":"RLY3 Voltage"},{"Analog Sensor Number":"11","Analog Sensor Name":"RLY4 Voltage"},{"Analog Sensor Number":"12","Analog Sensor Name":"WKUP"},{"Analog Sensor Number":"13","Analog Sensor Name":"VPP Voltage"},
-{"Analog Sensor Number":"14","Analog Sensor Name":"VIN Voltage"},{"Analog Sensor Number":"15","Analog Sensor Name":"ADC Temperature"},{"Analog Sensor Number":"16","Analog Sensor Name":"Cont Meas Period"},{"Analog Sensor Number":"17","Analog Sensor Name":"Cont Meas Count"}];var f=[],g="";if("VoBoXX"==a)f=c;else if("VoBoTC"==a)f=d;else if("VoBoXP"==a)f=e,c=(b&192)>>6,1==c?g="(Max)":2==c?g="(Min)":3==c&&(g="(Avg)"),b&=63;else throw errorMsg=a+' -- Invalid VoBo Type. Use "VoBoXX", "VoBoTC" or "VoBoXP"',
-Error(errorMsg);f=f.find(h=>h["Analog Sensor Number"]==b.toString());if("undefined"==typeof f)return"AnalogSensor"+b.toString();f=f["Analog Sensor Name"];"VoBoXP"==a&&(f=f+" "+g);return f}
+{"Analog Sensor Number":"14","Analog Sensor Name":"VIN Voltage"},{"Analog Sensor Number":"15","Analog Sensor Name":"ADC Temperature"},{"Analog Sensor Number":"16","Analog Sensor Name":"Cont Meas Period"},{"Analog Sensor Number":"17","Analog Sensor Name":"Cont Meas Count"}];var f=[],g="";if("VoBoXX"==a)f=c;else if("VoBoTC"==a)f=d;else if("VoBoXP"==a)f=e,c=(b&192)>>6,1==c?g=" (Max)":2==c?g=" (Min)":3==c&&(g=" (Avg)"),b&=63;else throw errorMsg=a+' -- Invalid VoBo Type. Use "VoBoXX", "VoBoTC" or "VoBoXP"',
+Error(errorMsg);f=f.find(h=>h["Analog Sensor Number"]==b.toString());if("undefined"==typeof f)return"AnalogSensor"+b.toString();f=f["Analog Sensor Name"];"VoBoXP"==a&&(f+=g);return f}
 function lookupDigitalSensorName(a,b){const c=[{"Digital Sensor Number":"0","Digital Sensor Name":"WKUP"},{"Digital Sensor Number":"1","Digital Sensor Name":"DIN1"},{"Digital Sensor Number":"2","Digital Sensor Name":"DIN2"},{"Digital Sensor Number":"3","Digital Sensor Name":"DIN3"}],d=[{"Digital Sensor Number":"0","Digital Sensor Name":"WKUP"}],e=[{"Digital Sensor Number":"0","Digital Sensor Name":"WKUP"},{"Digital Sensor Number":"1","Digital Sensor Name":"DIN1"},{"Digital Sensor Number":"2","Digital Sensor Name":"DIN2"}];
 var f=[];if("VoBoXX"==a)f=c;else if("VoBoTC"==a)f=d;else if("VoBoXP"==a)f=e;else throw errorMsg=a+' -- Invalid VoBo Type. Use "VoBoXX", "VoBoTC" or "VoBoXP"',Error(errorMsg);a=f.find(g=>g["Digital Sensor Number"]==b.toString());return"undefined"==typeof a?"DigitalSensor"+b.toString():a["Digital Sensor Name"]}
 function lookupUnits(a,b){var c="";c=[{"Units Code":"1",Description:"inches of water at 20 degC (68 degF)","Abbreviated Units":"inH2O (20 degC or 68 degF)"},{"Units Code":"2",Description:"inches of mercury at 0 degC (32 degF)","Abbreviated Units":"inHg (20 degC or 68 degF)"},{"Units Code":"3",Description:"feet of water at 20 degC (68 degF)","Abbreviated Units":"ftH2O (20 degC or 68 degF)"},{"Units Code":"4",Description:"millimeters of water at 20 degC (68 degF)","Abbreviated Units":"mmH2O (20 degC or 68 degF)"},
@@ -161,15 +188,15 @@ Description:"gallons per day","Abbreviated Units":"usg/d"},{"Units Code":"236",D
 // exports had to be commented out.
 //===========================================================
 
-const payload_vb = payload.find((x) => x.variable === "payload");
-const fPort_vb = payload.find((x) => x.variable === "port" || x.variable === "fPort")?.value;
+const payload_vb = payload.find((x) => x.variable === "payload_raw" || x.variable === "payload" || x.variable === "data");
+const fPort_vb = payload.find((x) => x.variable === "port" || x.variable === "fPort" || x.variable === "fport" || x.variable === "FPort")?.value;
 
 if (payload_vb) {
     try {
         const buffer = Buffer.from(payload_vb.value, "hex")
         const decoded = toTagoFormat(buffer, fPort_vb);
-        payload = decoded;
-    } catch (error: any) {
+        payload = payload.concat(decoded);
+    } catch (error) {
         console.error(error);
         payload = [{ variable: "parse_error", value: error.message }];
     }

--- a/decoders/connector/volley-boast/vobo-xp/v1.0.0/payload.js
+++ b/decoders/connector/volley-boast/vobo-xp/v1.0.0/payload.js
@@ -12,7 +12,7 @@ function customDecoder(bytes, fport) {
             {
                 variable: decoded.data.analogSensorString0,
                 value: decoded.data.sensorData0,
-                units: decoded.data.engUnitsString0
+                unit: decoded.data.engUnitsString0
             }
         ];
         tagoDecoded.push(
@@ -26,12 +26,12 @@ function customDecoder(bytes, fport) {
             {
                 variable: decoded.data.analogSensorString0,
                 value: decoded.data.sensorData0,
-                units: decoded.data.engUnitsString0
+                unit: decoded.data.engUnitsString0
             },
             {
                 variable: decoded.data.analogSensorString1,
                 value: decoded.data.sensorData1,
-                units: decoded.data.engUnitsString1
+                unit: decoded.data.engUnitsString1
             }
         ];
         tagoDecoded.push(
@@ -55,7 +55,7 @@ function customDecoder(bytes, fport) {
         var tagoDecoded = decoded.data.ainPayloads.map((payloadObj, index) => ({
             variable: decoded.data[`analogSensorString${index}`],
             value: payloadObj.sensorData0,
-            units: decoded.data[`engUnitsString${index}`]
+            unit: decoded.data[`engUnitsString${index}`]
         }));
         tagoDecoded.push(
             { variable: "fport", value: decoded.data.fport },

--- a/decoders/connector/volley-boast/vobo-xp/v1.0.0/payload.test.ts
+++ b/decoders/connector/volley-boast/vobo-xp/v1.0.0/payload.test.ts
@@ -17,7 +17,6 @@ const testPayloads = {
     ]
 }
 
-
 describe(`fPort: ${testPayloads.data[0].fport} - ${testPayloads.data[0].name}`, () => { // fPort 22
     const raw_payload = [
         { variable: "payload", value: testPayloads.data[0].payload },
@@ -26,26 +25,45 @@ describe(`fPort: ${testPayloads.data[0].fport} - ${testPayloads.data[0].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const batteryLevel = payload.find((item) => item.variable === 'batteryLevel');
+    const fatalErrorsTotal = payload.find((item) => item.variable === 'fatalErrorsTotal');
+    const rssiAvg = payload.find((item) => item.variable === 'rssiAvg');
+    const failedJoinAttemptsTotal = payload.find((item) => item.variable === 'failedJoinAttemptsTotal');
+    const configUpdateOccurred = payload.find((item) => item.variable === 'configUpdateOccurred');
+    const firmwareRevision = payload.find((item) => item.variable === 'firmwareRevision');
+    const rebootsTotal = payload.find((item) => item.variable === 'rebootsTotal');
+    const failedTransmitsTotal = payload.find((item) => item.variable === 'failedTransmitsTotal');
+    const errorEventLogsTotal = payload.find((item) => item.variable === 'errorEventLogsTotal');
+    const warningEventLogsTotal = payload.find((item) => item.variable === 'warningEventLogsTotal');
+    const infoEventLogsTotal = payload.find((item) => item.variable === 'infoEventLogsTotal');
+    const measurementPacketsTotal = payload.find((item) => item.variable === 'measurementPacketsTotal');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'batteryLevel', value: 3532 },
-            { variable: 'fatalErrorsTotal', value: 0 },
-            { variable: 'rssiAvg', value: 57 },
-            { variable: 'failedJoinAttemptsTotal', value: 0 },
-            { variable: 'configUpdateOccurred', value: 0 },
-            { variable: 'firmwareRevision', value: 0 },
-            { variable: 'rebootsTotal', value: 3 },
-            { variable: 'failedTransmitsTotal', value: 0 },
-            { variable: 'errorEventLogsTotal', value: 0 },
-            { variable: 'warningEventLogsTotal', value: 0 },
-            { variable: 'infoEventLogsTotal', value: 0 },
-            { variable: 'measurementPacketsTotal', value: 4 },
-            { variable: 'fport', value: 22 },
-            { variable: 'voboType', value: 'VoBoXP' },
-            { variable: 'payloadType', value: 'Heartbeat 2.0' }
-        ]);
+        expect(batteryLevel.value).toBe(3532);
+        expect(fatalErrorsTotal.value).toBe(0);
+        expect(rssiAvg.value).toBe(57);
+        expect(failedJoinAttemptsTotal.value).toBe(0);
+        expect(configUpdateOccurred.value).toBe(0);
+        expect(firmwareRevision.value).toBe(0);
+        expect(rebootsTotal.value).toBe(3);
+        expect(failedTransmitsTotal.value).toBe(0);
+        expect(errorEventLogsTotal.value).toBe(0);
+        expect(warningEventLogsTotal.value).toBe(0);
+        expect(infoEventLogsTotal.value).toBe(0);
+        expect(measurementPacketsTotal.value).toBe(4);
+        expect(fport.value).toBe(22);
+        expect(voboType.value).toBe('VoBoXP');
+        expect(payloadType.value).toBe('Heartbeat 2.0');
     });
 });
+
 describe(`fPort: ${testPayloads.data[1].fport} - ${testPayloads.data[1].name}`, () => { // fPort 32
     const raw_payload = [
         { variable: "payload", value: testPayloads.data[1].payload },
@@ -54,8 +72,21 @@ describe(`fPort: ${testPayloads.data[1].fport} - ${testPayloads.data[1].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const adcTemperature = payload.find((item) => item.variable === 'ADC Temperature');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual({ variable: 'ADC Temperature ', value: 26.375, units: 'C' });
+        expect(adcTemperature.value).toBe(26.375);
+        expect(adcTemperature.units).toBe("C")
+        expect(fport.value).toBe(32);
+        expect(voboType.value).toBe('VoBoXP');
+        expect(payloadType.value).toBe('One Analog Input');
     });
 });
 
@@ -67,15 +98,29 @@ describe(`fPort: ${testPayloads.data[2].fport} - ${testPayloads.data[2].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+
+    const ain1 = payload.find((item) => item.variable === 'AIN1');
+    const ain2 = payload.find((item) => item.variable === 'AIN2');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'AIN1 ', value: 9.999750137329102, units: 'mA' },
-            { variable: 'AIN2 ', value: 2.5325000286102295, units: 'V' }
-        ]);
+        expect(ain1.value).toBe(9.999750137329102);
+        expect(ain1.units).toBe('mA');
+        expect(ain2.value).toBe(2.5325000286102295);
+        expect(ain2.units).toBe('V');
+        expect(fport.value).toBe(42);
+        expect(voboType.value).toBe('VoBoXP');
+        expect(payloadType.value).toBe('Two Analog Inputs');
     });
 });
 
-describe(`fPort: ${testPayloads.data[3].fport} - ${testPayloads.data[3].name}`, () => { // fPort 52 
+describe(`fPort: ${testPayloads.data[3].fport} - ${testPayloads.data[3].name}`, () => { // fPort 52
     const raw_payload = [
         { variable: "payload", value: testPayloads.data[3].payload },
         { variable: "fPort", value: testPayloads.data[3].fport }
@@ -83,15 +128,24 @@ describe(`fPort: ${testPayloads.data[3].fport} - ${testPayloads.data[3].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const wkup = payload.find((item) => item.variable === 'WKUP');
+    const din1 = payload.find((item) => item.variable === 'DIN1');
+    const din2 = payload.find((item) => item.variable === 'DIN2');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'WKUP', value: 0 },
-            { variable: 'DIN1', value: 1 },
-            { variable: 'DIN2', value: 1 },
-            { variable: 'fport', value: 52 },
-            { variable: 'voboType', value: 'VoBoXP' },
-            { variable: 'payloadType', value: 'Digital Inputs' }
-        ]);
+        expect(wkup.value).toBe(0);
+        expect(din1.value).toBe(1);
+        expect(din2.value).toBe(1);
+        expect(fport.value).toBe(52);
+        expect(voboType.value).toBe('VoBoXP');
+        expect(payloadType.value).toBe('Digital Inputs');
     });
 });
 
@@ -103,15 +157,24 @@ describe(`fPort: ${testPayloads.data[4].fport} - ${testPayloads.data[4].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const eventTimestamp = payload.find((item) => item.variable === 'eventTimestamp');
+    const eventCode = payload.find((item) => item.variable === 'eventCode');
+    const metadata = payload.find((item) => item.variable === 'metadata');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'eventTimestamp', value: 1690115688 },
-            { variable: 'eventCode', value: 65535 },
-            { variable: 'metadata', value: [0, 0, 0, 0, 0] },
-            { variable: 'fport', value: 62 },
-            { variable: 'voboType', value: 'VoBoXP' },
-            { variable: 'payloadType', value: 'Event Log' }
-        ]);
+        expect(eventTimestamp.value).toBe(1690115688);
+        expect(eventCode.value).toBe(65535);
+        expect(metadata.value).toStrictEqual([0, 0, 0, 0, 0]);
+        expect(fport.value).toBe(62);
+        expect(voboType.value).toBe('VoBoXP');
+        expect(payloadType.value).toBe('Event Log');
     });
 });
 
@@ -123,31 +186,56 @@ describe(`fPort: ${testPayloads.data[5].fport} - ${testPayloads.data[5].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const subgroupID = payload.find((item) => item.variable === 'subgroupID');
+    const sequenceNumber = payload.find((item) => item.variable === 'sequenceNumber');
+    const transRejoin = payload.find((item) => item.variable === 'transRejoin');
+    const ackFrequency = payload.find((item) => item.variable === 'ackFrequency');
+    const lowVoltThreshold = payload.find((item) => item.variable === 'lowVoltThreshold');
+    const reserved1 = payload.find((item) => item.variable === 'reserved1');
+    const heartbeatAckEnable = payload.find((item) => item.variable === 'heartbeatAckEnable');
+    const operationMode = payload.find((item) => item.variable === 'operationMode');
+    const cycleSubBands = payload.find((item) => item.variable === 'cycleSubBands');
+    const ackRetries = payload.find((item) => item.variable === 'ackRetries');
+    const reservedLL = payload.find((item) => item.variable === 'reservedLL');
+    const ackEnable = payload.find((item) => item.variable === 'ackEnable');
+    const heartbeatEnable = payload.find((item) => item.variable === 'heartbeatEnable');
+    const cycleTime = payload.find((item) => item.variable === 'cycleTime');
+    const backOffReset = payload.find((item) => item.variable === 'backOffReset');
+    const reservedRD = payload.find((item) => item.variable === 'reservedRD');
+    const reserved2 = payload.find((item) => item.variable === 'reserved2');
+    const resendAttempts = payload.find((item) => item.variable === 'resendAttempts');
+    const freqSubBand = payload.find((item) => item.variable === 'freqSubBand');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'subgroupID', value: 0 },
-            { variable: 'sequenceNumber', value: 0 },
-            { variable: 'transRejoin', value: 10 },
-            { variable: 'ackFrequency', value: 4 },
-            { variable: 'lowBattery', value: 3.1 },
-            { variable: 'reserved1', value: 0 },
-            { variable: 'heartbeatAckEnable', value: true },
-            { variable: 'operationMode', value: 1 },
-            { variable: 'cycleSubBands', value: true },
-            { variable: 'ackRetries', value: 2 },
-            { variable: 'reservedLL', value: 4 },
-            { variable: 'ackEnable', value: true },
-            { variable: 'heartbeatEnable', value: true },
-            { variable: 'cycleTime', value: 60 },
-            { variable: 'backOffReset', value: 9 },
-            { variable: 'reservedRD', value: 5 },
-            { variable: 'reserved2', value: 0 },
-            { variable: 'resendAttempts', value: 0 },
-            { variable: 'freqSubBand', value: 2 },
-            { variable: 'fport', value: 72 },
-            { variable: 'voboType', value: 'VoBoXP' },
-            { variable: 'payloadType', value: 'Configuration' }
-        ]);
+        expect(subgroupID.value).toBe(0);
+        expect(sequenceNumber.value).toBe(0);
+        expect(transRejoin.value).toBe(10);
+        expect(ackFrequency.value).toBe(4);
+        expect(lowVoltThreshold.value).toBe(3.1);
+        expect(reserved1.value).toBe(0);
+        expect(heartbeatAckEnable.value).toBe(true);
+        expect(operationMode.value).toBe(1);
+        expect(cycleSubBands.value).toBe(true);
+        expect(ackRetries.value).toBe(2);
+        expect(reservedLL.value).toBe(4);
+        expect(ackEnable.value).toBe(true);
+        expect(heartbeatEnable.value).toBe(true);
+        expect(cycleTime.value).toBe(60);
+        expect(backOffReset.value).toBe(9);
+        expect(reservedRD.value).toBe(5);
+        expect(reserved2.value).toBe(0);
+        expect(resendAttempts.value).toBe(0);
+        expect(freqSubBand.value).toBe(2);
+        expect(fport.value).toBe(72);
+        expect(voboType.value).toBe('VoBoXP');
+        expect(payloadType.value).toBe('Configuration');
     });
 });
 
@@ -159,13 +247,20 @@ describe(`fPort: ${testPayloads.data[6].fport} - ${testPayloads.data[6].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const group3register1 = payload.find((item) => item.variable === 'group3register1');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'group3register1', value: 531 },
-            { variable: 'fport', value: 102 },
-            { variable: 'voboType', value: 'VoBoXP' },
-            { variable: 'payloadType', value: 'Modbus Generic' }
-        ]);
+        expect(group3register1.value).toBe(531);
+        expect(fport.value).toBe(102);
+        expect(voboType.value).toBe('VoBoXP');
+        expect(payloadType.value).toBe('Modbus Generic');
     });
 });
 
@@ -178,18 +273,27 @@ describe(`fPort: ${testPayloads.data[7].fport} - ${testPayloads.data[7].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const ain1 = payload.find((item) => item.variable === 'AIN1');
+    const ain2 = payload.find((item) => item.variable === 'AIN2');
+    const ain3 = payload.find((item) => item.variable === 'AIN3');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'AIN1 ', value: 1, units: 'ADC code' },
-            { variable: 'AIN2 ', value: 2, units: 'ADC code' },
-            { variable: 'AIN3 ', value: 1, units: 'ADC code' },
-            {
-                variable: '3.3V Supply Voltage ',
-                value: 3.375999927520752,
-                units: 'V'
-            },
-            { variable: 'ADC Temperature ', value: 22.75, units: 'C' }
-        ]);
+        expect(ain1.value).toBe(1);
+        expect(ain1.units).toBe('ADC code');
+        expect(ain2.value).toBe(2);
+        expect(ain2.units).toBe('ADC code');
+        expect(ain3.value).toBe(1);
+        expect(ain3.units).toBe('ADC code');
+        expect(fport.value).toBe(112);
+        expect(voboType.value).toBe('VoBoXP');
+        expect(payloadType.value).toBe('Analog Input Variable Length');
     });
 });
 
@@ -201,16 +305,32 @@ describe(`fPort: ${testPayloads.data[8].fport} - ${testPayloads.data[8].name}`, 
 
     const payload = decoderRun(file_path, { payload: raw_payload });
 
+    test("Output Result", () => {
+        expect(Array.isArray(payload)).toBe(true);
+    });
+
+    const modbus1 = payload.find((item) => item.variable === 'Modbus1');
+    const modbus2 = payload.find((item) => item.variable === 'Modbus2');
+    const modbus3 = payload.find((item) => item.variable === 'Modbus3');
+    const modbus4 = payload.find((item) => item.variable === 'Modbus4');
+    const modbus5 = payload.find((item) => item.variable === 'Modbus5');
+    const modbus6 = payload.find((item) => item.variable === 'Modbus6');
+    const modbus7 = payload.find((item) => item.variable === 'Modbus7');
+    const fport = payload.find((item) => item.variable === 'fport');
+    const voboType = payload.find((item) => item.variable === 'voboType');
+    const payloadType = payload.find((item) => item.variable === 'payloadType');
+
     test("Check if data is correct", () => {
-        expect(payload).toStrictEqual([
-            { variable: 'Modbus1', value: 9999 },
-            { variable: 'Modbus2', value: 9999 },
-            { variable: 'Modbus3', value: 9999 },
-            { variable: 'Modbus4', value: 9999 },
-            { variable: 'Modbus5', value: 9999 },
-            { variable: 'Modbus6', value: 9999 },
-            { variable: 'Modbus7', value: 9999 }
-        ]);
+        expect(modbus1.value).toBe(9999);
+        expect(modbus2.value).toBe(9999);        
+        expect(modbus3.value).toBe(9999);
+        expect(modbus4.value).toBe(9999);
+        expect(modbus5.value).toBe(9999);
+        expect(modbus6.value).toBe(9999);
+        expect(modbus7.value).toBe(9999);
+        expect(fport.value).toBe(122);
+        expect(voboType.value).toBe('VoBoXP');
+        expect(payloadType.value).toBe('Modbus Standard Variable Length');
     });
 });
 

--- a/decoders/connector/volley-boast/vobo-xp/v1.0.0/payload.test.ts
+++ b/decoders/connector/volley-boast/vobo-xp/v1.0.0/payload.test.ts
@@ -83,7 +83,7 @@ describe(`fPort: ${testPayloads.data[1].fport} - ${testPayloads.data[1].name}`, 
 
     test("Check if data is correct", () => {
         expect(adcTemperature.value).toBe(26.375);
-        expect(adcTemperature.units).toBe("C")
+        expect(adcTemperature.unit).toBe("C")
         expect(fport.value).toBe(32);
         expect(voboType.value).toBe('VoBoXP');
         expect(payloadType.value).toBe('One Analog Input');
@@ -111,9 +111,9 @@ describe(`fPort: ${testPayloads.data[2].fport} - ${testPayloads.data[2].name}`, 
 
     test("Check if data is correct", () => {
         expect(ain1.value).toBe(9.999750137329102);
-        expect(ain1.units).toBe('mA');
+        expect(ain1.unit).toBe('mA');
         expect(ain2.value).toBe(2.5325000286102295);
-        expect(ain2.units).toBe('V');
+        expect(ain2.unit).toBe('V');
         expect(fport.value).toBe(42);
         expect(voboType.value).toBe('VoBoXP');
         expect(payloadType.value).toBe('Two Analog Inputs');
@@ -286,11 +286,11 @@ describe(`fPort: ${testPayloads.data[7].fport} - ${testPayloads.data[7].name}`, 
 
     test("Check if data is correct", () => {
         expect(ain1.value).toBe(1);
-        expect(ain1.units).toBe('ADC code');
+        expect(ain1.unit).toBe('ADC code');
         expect(ain2.value).toBe(2);
-        expect(ain2.units).toBe('ADC code');
+        expect(ain2.unit).toBe('ADC code');
         expect(ain3.value).toBe(1);
-        expect(ain3.units).toBe('ADC code');
+        expect(ain3.unit).toBe('ADC code');
         expect(fport.value).toBe(112);
         expect(voboType.value).toBe('VoBoXP');
         expect(payloadType.value).toBe('Analog Input Variable Length');


### PR DESCRIPTION
Fixes: Concatenated decode payload with original payload dayload per TagoIO request. Updated test files for each device. Updated payload.js (decoder) for each device along with the toTagoFormat function. Added extra keyword to find fport within payload.

## Decoder Description

Explain the functionality of your decoder or any other relevant information.

## Type of change

- [ ] Adding a new Decoder of Connector
- [ ] Adding a new Decoder of Network
- [X] Update or fixing an issue in existing Decoder

## Decoder Information and Payload to test and review

- [ ] Documentation of the hardware or protocol:
- [ ] Payload of example the test the decoder:


## Checklist for Adding a New Decoder

- [ ] Created a new folder under `./decoders/network/` or `./decoders/connector/` with the name of your decoder.
- [ ] Added a `network.jsonc` or `connector.jsonc` file that follows the structure defined in `./schema/`.
- [ ] Created version folders and added `manifest.jsonc` files for each version.
- [ ] Followed the folder structure guidelines for manufacturer and sensor/device model.
- [ ] The code has unit test and it's in TypeScript.

## Additional Notes

Please add any other information that you think is important.

