### PR TITLE
Added support for fPort variable.

### DIFF
--- a/decoders/connector/dragino/wl03alb/v1.0.0/payload.ts
+++ b/decoders/connector/dragino/wl03alb/v1.0.0/payload.ts
@@ -162,13 +162,13 @@ function Decoder(bytes: Buffer, port: number) {
 
 const wl03alb_payload = payload.find((x) => x.variable === "payload_raw" || x.variable === "payload" || x.variable === "data");
 
-const port = payload.find((x) => x.variable === "port" || x.variable === "fport");
+const port = payload.find((x) => x.variable === "port" || x.variable === "fport" || x.variable === "fPort");
 
-if (wl03alb_payload) {
+if (wl03alb_payload && port) {
   try {
     // Convert the data from Hex to Javascript Buffer.
     const buffer = Buffer.from(wl03alb_payload.value, "hex");
-    const group = new Date().getTime();
+    const group = port.group || String(new Date().getTime());
     const payload_aux = Decoder(buffer, Number(port.value));
     payload = payload.concat(toTagoFormat(payload_aux, group));
   } catch (e) {


### PR DESCRIPTION
## Decoder Description

Enhance Dragino WL03ALB decoder: Added support for 'fPort' variable and improved payload handling logic to ensure both payload and port are present before processing.

## Type of change

- [ ] Adding a new Decoder of Connector
- [ ] Adding a new Decoder of Network
- [x] Update or fixing an issue in existing Decoder

## Decoder Information and Payload to test and review

- [ ] Documentation of the hardware or protocol:
- [ ] Payload of example the test the decoder:


## Checklist for Adding a New Decoder

- [ ] Created a new folder under `./decoders/network/` or `./decoders/connector/` with the name of your decoder.
- [ ] Added a `network.jsonc` or `connector.jsonc` file that follows the structure defined in `./schema/`.
- [ ] Created version folders and added `manifest.jsonc` files for each version.
- [ ] Followed the folder structure guidelines for manufacturer and sensor/device model.
- [ ] The code has unit test and it's in TypeScript.

## Additional Notes

Please add any other information that you think is important.

