### PR TITLE
feat: add support for lorawan-senet payload in netvox connector configurations

### DIFF
--- a/decoders/connector/netvox/r711/v1.0.0/payload-config.jsonc
+++ b/decoders/connector/netvox/r711/v1.0.0/payload-config.jsonc
@@ -18,6 +18,7 @@
     "../../../../network/lorawan-swisscom/v1.0.0/payload.js",
     "../../../../network/lorawan-chirpstack/v1.0.0/payload.js",
     "../../../../network/lorawan-helium/v1.0.0/payload.js",
-    "../../../../network/lorawan-brdot/v1.0.0/payload.js"
+    "../../../../network/lorawan-brdot/v1.0.0/payload.js",
+    "../../../../network/lorawan-senet/v1.0.0/payload.js"
   ]
 }

--- a/decoders/connector/netvox/r712/v1.0.0/payload-config.jsonc
+++ b/decoders/connector/netvox/r712/v1.0.0/payload-config.jsonc
@@ -18,6 +18,7 @@
     "../../../../network/lorawan-swisscom/v1.0.0/payload.js",
     "../../../../network/lorawan-chirpstack/v1.0.0/payload.js",
     "../../../../network/lorawan-helium/v1.0.0/payload.js",
-    "../../../../network/lorawan-brdot/v1.0.0/payload.js"
+    "../../../../network/lorawan-brdot/v1.0.0/payload.js",
+    "../../../../network/lorawan-senet/v1.0.0/payload.js"
   ]
 }


### PR DESCRIPTION
## Decoder Description

Adding senet network option for Netvox R711 and R712.

## Type of change

- [ ] Adding a new Decoder of Connector
- [ ] Adding a new Decoder of Network
- [X] Update or fixing an issue in existing Decoder

## Decoder Information and Payload to test and review

- [ ] Documentation of the hardware or protocol:
- [ ] Payload of example the test the decoder:


## Checklist for Adding a New Decoder

- [ ] Created a new folder under `./decoders/network/` or `./decoders/connector/` with the name of your decoder.
- [ ] Added a `network.jsonc` or `connector.jsonc` file that follows the structure defined in `./schema/`.
- [ ] Created version folders and added `manifest.jsonc` files for each version.
- [ ] Followed the folder structure guidelines for manufacturer and sensor/device model.
- [ ] The code has unit test and it's in TypeScript.

## Additional Notes

Please add any other information that you think is important.

