### PR TITLE
fix: improve payload parsing and error handling for digi x-on

### DIFF
--- a/decoders/network/digi-x-on/v1.0.0/payload.ts
+++ b/decoders/network/digi-x-on/v1.0.0/payload.ts
@@ -1,5 +1,19 @@
 const data = payload.find((x) => x.variable === "payload");
+const port = payload.find((x) => x.variable === "port");
 
-if (data) {
-  payload = JSON.parse(data.value);
+// If we got "payload" and no "port", assume "payload.value" is a JSON string
+if (data && (port === undefined || port === null)) {
+  try {
+    const parsed = JSON.parse(data.value);
+
+    // Payload Parser must end with an Array of TagoIO data objects
+    // (per TagoIO docs about payload being what gets stored)
+    if (Array.isArray(parsed)) {
+      payload = parsed;
+    } else {
+      console.error("Parsed JSON is not an array. Keeping original payload.");
+    }
+  } catch (e) {
+    console.error("Invalid JSON in payload.value. Keeping original payload.", e);
+  }
 }


### PR DESCRIPTION
Enhance payload parsing logic to handle cases where 'port' is undefined or null. Added error handling for invalid JSON.

## Type of change

- [ ] Adding a new Decoder of Connector
- [ ] Adding a new Decoder of Network
- [ X] Update or fixing an issue in existing Decoder

## Additional Notes

Just a fix to allow digi x-on networks to send TagoIO proprietary format.
