### PR TITLE
Fix: endpoint URLs for digi-x-on 

### DIFF
--- a/decoders/network/digi-x-on/v1.0.0/payload-config.jsonc
+++ b/decoders/network/digi-x-on/v1.0.0/payload-config.jsonc
@@ -8,7 +8,7 @@
   },
   "device_parameters": [],
   "middleware_endpoint": {
-    "us-e1": "digixon.middleware.us-e1.tago.io",
-    "eu-w1": "digixon.middleware.eu-w1.tago.io"
+    "us-e1": "digi-xon.middleware.us-e1.tago.io",
+    "eu-w1": "digi-xon.middleware.eu-w1.tago.io"
   }
 }


### PR DESCRIPTION
## Decoder Description

Fix wrong endpoint for Digi-XON middleware, required for the downlink support.

## Type of change

- [X] Update or fixing an issue in existing Network

