### PR TITLE
Rename EC312-LoRaWAN connector to InHand EC312-LoRaWAN

### DIFF
--- a/decoders/connector/inhand-networks/EC312-LoRaWAN/connector.jsonc
+++ b/decoders/connector/inhand-networks/EC312-LoRaWAN/connector.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "../../../../schema/connector.json",
-  "name": "EC312-LoRaWAN",
+  "name": "InHand EC-LoRaWAN",
   "images": {
     "logo": "./assets/logo.png"
   },

--- a/decoders/connector/inhand-networks/EC312-LoRaWAN/connector.jsonc
+++ b/decoders/connector/inhand-networks/EC312-LoRaWAN/connector.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "../../../../schema/connector.json",
-  "name": "InHand EC-LoRaWAN",
+  "name": "InHand EC312-LoRaWAN",
   "images": {
     "logo": "./assets/logo.png"
   },

--- a/decoders/connector/inhand-networks/EC312-LoRaWAN/v1.0.0/payload-config.jsonc
+++ b/decoders/connector/inhand-networks/EC312-LoRaWAN/v1.0.0/payload-config.jsonc
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../../../schema/connector_details.json",
   "description": "../description.md",
-  "install_text": "**InHand EC-LoRaWAN**\n\nUse this connector for LoRaWAN end-devices connected through an InHand EC-LoRaWAN edge computer. Uplinks reach TagoIO via the LoRaWAN ChirpStack network integration; this connector normalizes the raw frame payload to hexadecimal and passes the remaining variables through unchanged.",
+  "install_text": "**InHand EC312-LoRaWAN**\n\nUse this connector for LoRaWAN end-devices connected through an InHand EC312-LoRaWAN edge computer. Uplinks reach TagoIO via the LoRaWAN ChirpStack network integration; this connector normalizes the raw frame payload to hexadecimal and passes the remaining variables through unchanged.",
   "install_end_text": "",
   "device_annotation": "",
   "device_parameters": [],

--- a/decoders/connector/inhand-networks/EC312-LoRaWAN/v1.0.0/payload-config.jsonc
+++ b/decoders/connector/inhand-networks/EC312-LoRaWAN/v1.0.0/payload-config.jsonc
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../../../schema/connector_details.json",
   "description": "../description.md",
-  "install_text": "**EC312-LoRaWAN**\n\nUse this connector for LoRaWAN end-devices connected through an EC312-LoRaWAN edge computer. Uplinks reach TagoIO via the LoRaWAN ChirpStack network integration; this connector normalizes the raw frame payload to hexadecimal and passes the remaining variables through unchanged.",
+  "install_text": "**InHand EC-LoRaWAN**\n\nUse this connector for LoRaWAN end-devices connected through an InHand EC-LoRaWAN edge computer. Uplinks reach TagoIO via the LoRaWAN ChirpStack network integration; this connector normalizes the raw frame payload to hexadecimal and passes the remaining variables through unchanged.",
   "install_end_text": "",
   "device_annotation": "",
   "device_parameters": [],


### PR DESCRIPTION
## Summary
- Rename the connector display name from `EC312-LoRaWAN` to `InHand EC312-LoRaWAN` in `connector.jsonc`
- Update the `install_text` header and device mention in `payload-config.jsonc` to match

## Test plan
- [ ] `pnpm start validator` passes
- [ ] CI checks pass